### PR TITLE
init travis-ci configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: java
+jdk:
+  - oraclejdk8
+cache:
+  directories:
+  - $HOME/.gradle
+
+branches:
+  only:
+    - master
+    - develop
+    - /^feature-.*$/
+    - /^fix-.*$/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# autosleep
+# autosleep [![Build Status](https://travis-ci.org/Orange-OpenSource/autosleep.svg?branch=develop)](https://travis-ci.org/Orange-OpenSource/autosleep)
 # Goal
 The aim of the auto-sleep project is to give the ability for Cloud Foundry users to automatically have their app stopped after a given period of inactivity, and then automatically started when accessed.
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,8 @@ buildscript {
 }
 apply plugin: 'java'
 apply plugin: 'spring-boot'
+apply plugin: 'findbugs'
+apply plugin: 'pmd'
 
 
 sourceCompatibility = 1.8
@@ -46,6 +48,10 @@ task wrapper(type: Wrapper) {
 
 
 tasks.test.dependsOn(cucumber)
+
+pmd {
+    consoleOutput true
+}
 
 dependencies {
     // Lombok

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Oct 12 14:31:33 CEST 2015
+#Tue Oct 13 10:25:50 CEST 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.7-all.zip


### PR DESCRIPTION
Basic init for travis CI : build, cucumber test, findbugs and PMD. 
Changed gradle-wrapper to 'all' to have completion on build.gradle
