### PR TITLE
Add context initializer to auto-set profile

### DIFF
--- a/src/main/java/org/cloudfoundry/autosleep/Application.java
+++ b/src/main/java/org/cloudfoundry/autosleep/Application.java
@@ -1,8 +1,9 @@
 package org.cloudfoundry.autosleep;
 
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.SpringApplication;
+import org.cloudfoundry.autosleep.config.ContextInitializer;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
@@ -15,8 +16,12 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 public class Application {
     
     public static void main(String[] args) {
-        SpringApplication.run(Application.class, args);
+       // SpringApplication.run(Application.class, args);
+        new SpringApplicationBuilder(Application.class)
+                .initializers(new ContextInitializer())
+                .run(args);
         log.debug("Application started");
     }
+
 
 }

--- a/src/main/java/org/cloudfoundry/autosleep/config/data/InMemoryConfig.java
+++ b/src/main/java/org/cloudfoundry/autosleep/config/data/InMemoryConfig.java
@@ -18,12 +18,11 @@ public class InMemoryConfig {
 
     @PostConstruct
     public void logProfile() {
-        log.warn("<<<<<<<<<<<  Warning: loading IN MEMORY persistance profile >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
+        log.warn("<<<<<<<<<<<  Warning: loading IN MEMORY persistance profile >>>>>>>>>>>>>>>>>>");
     }
 
     @Bean
     public ServiceRepository ramServiceRepository() {
-        log.debug("------------ loading IN MEMORY profile--------");
         return new RamServiceRepository();
     }
 

--- a/src/test/java/org/cloudfoundry/autosleep/admin/controller/DebugControllerTest.java
+++ b/src/test/java/org/cloudfoundry/autosleep/admin/controller/DebugControllerTest.java
@@ -14,7 +14,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.ActiveProfiles;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;


### PR DESCRIPTION
Add a context initializer that will:
- detect if in a cloud context, and if such check if one authorized persistence service is available (just redis for now)
- if in a local context, check if profile given through env var is authorized
- set default profile(in-memory db) if none of the above available
