### PR TITLE
FIX: BasicAuth read in environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,5 +38,8 @@ Once bound, your application will be watch for inactivity. If you wish to stop t
 # How to build
 If you wish to build the app yourself, go to [build documentation] (doc/build.md).
 
+# How to publish
+Once you built the application or if you got it from [latest release] (https://github.com/Orange-OpenSource/autosleep/releases/), go to [build documentation] (doc/publish.md).
+
 # How to test
 Acceptance tests are available in the source code, as robotframework tests. More information [here] (doc/test.md).

--- a/doc/publish.md
+++ b/doc/publish.md
@@ -4,29 +4,9 @@ How to make autosleep service broker available in your market place.
 ## Deploy autosleep application
 This is how to deploy autosleep application in cloudfoundry. If you wish to run it elsewhere you're on your own.
 ### Retrieve war
-Download war from [latest release] (https://github.com/Orange-OpenSource/autosleep/releases/), or [build it yourself] (build.md).
+Download war and associated _manifest.tmpl.yml_ from [latest release] (https://github.com/Orange-OpenSource/autosleep/releases/), or [build it yourself] (build.md).
 ### Prepare your manifest
-Make a *manifest.yml* file according to this template:
-
-```
-applications:
-- name: autosleep
-  memory: 1G
-  instances: 1
-  host: <your-route>
-  domain: <your-domain>
-  services:
-     - redis
-  buildpack: java_buildpack
-  env:
-    JAVA_OPTS: >
-      -Dcf.client.target.endpoint=<endpoint>
-      -Dcf.client.skip.ssl.validation=false
-      -Dcf.client.username=<username>
-      -Dcf.client.password=<password>
-      -Dcf.client.clientId=<client_id>
-      -Dcf.client.clientSecret=<client_secret>
-```
+Make a *manifest.yml* file according to the manifest.tmpl.yml template.
 ### Deploy your app
 ```
 cf push -f manifest.yml -p org.cloudfoundry.autosleep.war 
@@ -38,3 +18,4 @@ Check that the autosleep application is running and retrieve its url (`cf app au
 
 Then run the following command:
 ```cf create-service-broker autosleep LOGIN PASSWORD http://your-autsleep-route```
+where ___LOGIN___ and ___PASSWORD___ are the values you provided in the _manifest.yml_ file for environment properties ___security.user.name___ and ___security.user.password___

--- a/manifest.tmpl.yml
+++ b/manifest.tmpl.yml
@@ -4,12 +4,13 @@ applications:
   instances: 1
   host: autosleep
   domain: cf.ns.nd-paas.itn.ftgroup
-  path: build/libs/org.cloudfoundry.autosleep-0.2.0.war
   services:
     - redis
   buildpack: java_buildpack
   env:
     JAVA_OPTS: >
+      -Dsecurity.user.name=<security username>
+      -Dsecurity.user.password=<security password>
       -Dcf.client.target.endpoint=<endpoint>
       -Dcf.client.skip.ssl.validation=false
       -Dcf.client.username=<username>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,0 @@
-security.user.name=oto
-security.user.password=slip

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,2 @@
+security.user.name=oto
+security.user.password=slip


### PR DESCRIPTION
According to [issue](https://github.com/Orange-OpenSource/autosleep/issues/35)
- Remove application.properties
- Add security properties in manifest template
- Add application.properties in src/test/resources for unit test
- Update documentation
