### PR TITLE
Feature: opt-out

### DIFF
--- a/src/main/java/org/cloudfoundry/autosleep/admin/controller/DebugController.java
+++ b/src/main/java/org/cloudfoundry/autosleep/admin/controller/DebugController.java
@@ -12,9 +12,12 @@ import org.cloudfoundry.community.servicebroker.exception.ServiceInstanceDoesNot
 import org.cloudfoundry.community.servicebroker.model.Catalog;
 import org.cloudfoundry.community.servicebroker.model.ServiceDefinition;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.servlet.ModelAndView;
 
@@ -100,13 +103,22 @@ public class DebugController {
         return result;
     }
 
-    @RequestMapping("/services/applications/")
+    @RequestMapping(value = "/services/applications/")
     @ResponseBody
     public List<ApplicationInfo> listApplications() {
         log.debug("listApplications");
         List<ApplicationInfo> result = new ArrayList<>();
         applicationRepository.findAll().forEach(result::add);
         return result;
+    }
+
+
+    @RequestMapping(value = "/services/applications/{applicationId}", method = RequestMethod.DELETE)
+    public ResponseEntity<String> deleteApplication(@PathVariable("applicationId") String applicationId) {
+        log.debug("deleteApplication - {}", applicationId);
+        applicationRepository.delete(applicationId);
+        log.debug("deleteApplication - deleted");
+        return new ResponseEntity<>("{}", HttpStatus.NO_CONTENT);
     }
 
 }

--- a/src/main/java/org/cloudfoundry/autosleep/config/Config.java
+++ b/src/main/java/org/cloudfoundry/autosleep/config/Config.java
@@ -4,5 +4,10 @@ import java.time.Duration;
 
 public interface Config {
     Duration defaultInactivityPeriod = Duration.ofDays(1);
+
+    Duration defaultServiceBindingRefresh = Duration.ofDays(1);
+
     int nbThreadForTask = 5;
+
+    Duration delayBeforeFirstServiceCheck = Duration.ofSeconds(10);
 }

--- a/src/main/java/org/cloudfoundry/autosleep/dao/model/ApplicationInfo.java
+++ b/src/main/java/org/cloudfoundry/autosleep/dao/model/ApplicationInfo.java
@@ -67,7 +67,7 @@ public class ApplicationInfo {
         this.appState = activity.getState();
         this.lastEvent = activity.getLastEvent();
         this.lastLog = activity.getLastLog();
-        this.name = activity.getName();
+        this.name = activity.getApplication().getName();
     }
 
     public void setCheckTimes(Instant last, Instant next) {

--- a/src/main/java/org/cloudfoundry/autosleep/remote/ApplicationActivity.java
+++ b/src/main/java/org/cloudfoundry/autosleep/remote/ApplicationActivity.java
@@ -5,15 +5,12 @@ import lombok.Getter;
 import org.cloudfoundry.client.lib.domain.CloudApplication.AppState;
 
 import java.time.Instant;
-import java.util.UUID;
 
 @Getter
 @AllArgsConstructor
 public class ApplicationActivity {
 
-    private UUID guid;
-
-    private String name;
+    private ApplicationIdentity application;
 
     private AppState state;
 

--- a/src/main/java/org/cloudfoundry/autosleep/remote/ApplicationIdentity.java
+++ b/src/main/java/org/cloudfoundry/autosleep/remote/ApplicationIdentity.java
@@ -1,0 +1,14 @@
+package org.cloudfoundry.autosleep.remote;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+public class ApplicationIdentity {
+    private UUID guid;
+
+    private String name;
+}

--- a/src/main/java/org/cloudfoundry/autosleep/remote/CloudFoundryApiService.java
+++ b/src/main/java/org/cloudfoundry/autosleep/remote/CloudFoundryApiService.java
@@ -2,15 +2,20 @@ package org.cloudfoundry.autosleep.remote;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 public interface CloudFoundryApiService {
 
     ApplicationActivity getApplicationActivity(UUID appUid);
 
 
-    void stopApplication(UUID appUid);
+    void stopApplication(UUID applicationUuid);
 
-    void startApplication(UUID appUid);
+    void startApplication(UUID applicationUuid);
 
-    List<UUID> listApplications(UUID spaceUuid, String excludeNamesExpression);
+    List<ApplicationIdentity> listApplications(UUID spaceUuid, Pattern excludeNames);
+
+    void bindServiceInstance(ApplicationIdentity application, String serviceInstanceId);
+
+    void bindServiceInstance(List<ApplicationIdentity> application, String serviceInstanceId);
 }

--- a/src/main/java/org/cloudfoundry/autosleep/scheduling/AbstractPeriodicTask.java
+++ b/src/main/java/org/cloudfoundry/autosleep/scheduling/AbstractPeriodicTask.java
@@ -1,0 +1,45 @@
+package org.cloudfoundry.autosleep.scheduling;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.Duration;
+import java.time.Instant;
+
+@Slf4j
+@AllArgsConstructor
+abstract class AbstractPeriodicTask implements Runnable {
+
+    private Clock clock;
+
+    @Getter(value = AccessLevel.PROTECTED)
+    private Duration period;
+
+    public void start(Duration delay) {
+        log.debug("start - {}", delay);
+        clock.scheduleTask(getTaskId(), delay == null ? Duration.ofSeconds(0) : delay, this);
+    }
+
+    public void startNow() {
+        start(Duration.ofSeconds(0));
+    }
+
+    protected Instant reschedule(Duration delta) {
+        log.debug("Rescheduling in {}", delta.toString());
+        clock.scheduleTask(getTaskId(), delta, this);
+        return Instant.now().plus(delta);
+    }
+
+    protected Instant rescheduleWithDefaultPeriod() {
+        return reschedule(period);
+    }
+
+    protected abstract String getTaskId();
+
+    protected void stopTask() {
+        clock.removeTask(getTaskId());
+    }
+
+}

--- a/src/main/java/org/cloudfoundry/autosleep/scheduling/ApplicationBinder.java
+++ b/src/main/java/org/cloudfoundry/autosleep/scheduling/ApplicationBinder.java
@@ -1,0 +1,76 @@
+package org.cloudfoundry.autosleep.scheduling;
+
+import lombok.Builder;
+import lombok.extern.slf4j.Slf4j;
+import org.cloudfoundry.autosleep.dao.model.AutosleepServiceInstance;
+import org.cloudfoundry.autosleep.dao.repositories.ApplicationRepository;
+import org.cloudfoundry.autosleep.dao.repositories.ServiceRepository;
+import org.cloudfoundry.autosleep.remote.CloudFoundryApiService;
+import org.cloudfoundry.autosleep.remote.ApplicationIdentity;
+
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class ApplicationBinder extends AbstractPeriodicTask {
+
+
+    private final String serviceInstanceId;
+
+    private final CloudFoundryApiService cloudFoundryApi;
+
+    private final ServiceRepository serviceRepository;
+
+    private final ApplicationRepository applicationRepository;
+
+    @Builder
+    ApplicationBinder(Clock clock, Duration period, String serviceInstanceId,
+                      CloudFoundryApiService cloudFoundryApi, ServiceRepository serviceRepository,
+                      ApplicationRepository applicationRepository) {
+        super(clock, period);
+        this.serviceInstanceId = serviceInstanceId;
+        this.cloudFoundryApi = cloudFoundryApi;
+        this.serviceRepository = serviceRepository;
+        this.applicationRepository = applicationRepository;
+    }
+
+    @Override
+    public void run() {
+        AutosleepServiceInstance serviceInstance = serviceRepository.findOne(serviceInstanceId);
+        if (serviceInstance != null) {
+            Set<UUID> watchedApplications = new HashSet<>();
+            applicationRepository.findAll()
+                    .forEach(applicationInfo -> watchedApplications.add(applicationInfo.getUuid()));
+            log.debug("{} local applications", watchedApplications.size());
+            List<ApplicationIdentity> applicationIdentities = cloudFoundryApi
+                    .listApplications(UUID.fromString(serviceInstance.getSpaceGuid()),
+                            serviceInstance.getExcludeNames());
+            if (applicationIdentities != null) {
+                List<ApplicationIdentity> newApplications = applicationIdentities.stream()
+                        .filter(application -> !watchedApplications.contains(application.getGuid()))
+                        .collect(Collectors.toList());
+                if (!newApplications.isEmpty()) {
+                    log.debug("{} - new applications", newApplications.size());
+                    cloudFoundryApi.bindServiceInstance(newApplications, serviceInstance.getServiceInstanceId());
+                } else {
+                    log.debug("all applications are binded");
+                }
+            } else {
+                log.debug("no remote application returned");
+            }
+            rescheduleWithDefaultPeriod();
+        } else {
+            log.debug("service has been removed. Cancelling task");
+            stopTask();
+        }
+    }
+
+    @Override
+    protected String getTaskId() {
+        return serviceInstanceId;
+    }
+}

--- a/src/main/java/org/cloudfoundry/autosleep/scheduling/GlobalWatcher.java
+++ b/src/main/java/org/cloudfoundry/autosleep/scheduling/GlobalWatcher.java
@@ -1,6 +1,7 @@
 package org.cloudfoundry.autosleep.scheduling;
 
 import lombok.extern.slf4j.Slf4j;
+import org.cloudfoundry.autosleep.config.Config;
 import org.cloudfoundry.autosleep.dao.model.ApplicationBinding;
 import org.cloudfoundry.autosleep.dao.repositories.ApplicationRepository;
 import org.cloudfoundry.autosleep.dao.repositories.BindingRepository;
@@ -19,22 +20,25 @@ public class GlobalWatcher {
 
     private Clock clock;
 
-    private CloudFoundryApiService remote;
-
     private BindingRepository bindingRepository;
 
     private ServiceRepository serviceRepository;
 
     private ApplicationRepository applicationRepository;
 
+    private CloudFoundryApiService cloudFoundryApi;
+
+
     @Autowired
-    public GlobalWatcher(Clock clock, CloudFoundryApiService remote, BindingRepository bindingRepository,
-                         ServiceRepository serviceRepository, ApplicationRepository applicationRepository) {
+    public GlobalWatcher(Clock clock, BindingRepository bindingRepository,
+                         ServiceRepository serviceRepository, ApplicationRepository applicationRepository,
+                         CloudFoundryApiService cloudFoundryApi) {
         this.clock = clock;
-        this.remote = remote;
+        this.cloudFoundryApi = cloudFoundryApi;
         this.bindingRepository = bindingRepository;
         this.serviceRepository = serviceRepository;
         this.applicationRepository = applicationRepository;
+        this.cloudFoundryApi = cloudFoundryApi;
     }
 
     @PostConstruct
@@ -42,18 +46,35 @@ public class GlobalWatcher {
         log.debug("Initializer watchers for every app already bound (except if handle by another instance of "
                 + "autosleep)");
         bindingRepository.findAll().forEach(this::watchApp);
+        serviceRepository.findAll()
+                .forEach(autosleepServiceInstance ->
+                        watchServiceBindings(autosleepServiceInstance.getServiceInstanceId(), null));
     }
 
     public void watchApp(ApplicationBinding binding) {
         Duration interval = serviceRepository.findOne(binding.getServiceInstanceId()).getInterval();
         log.debug("Initializing a watch on app {}, for an interval of {} ", binding.getAppGuid(), interval.toString());
-        AppStateChecker checker = new AppStateChecker(UUID.fromString(binding.getAppGuid()),
-                binding.getId(),
-                interval,
-                remote,
-                clock,
-                applicationRepository);
-        checker.start();
+        AppStateChecker checker = AppStateChecker.builder()
+                .clock(clock)
+                .period(interval)
+                .appUid(UUID.fromString(binding.getAppGuid()))
+                .cloudFoundryApi(cloudFoundryApi)
+                .bindingId(binding.getId())
+                .applicationRepository(applicationRepository)
+                .build();
+        checker.startNow();
+    }
+
+    public void watchServiceBindings(String serviceId, Duration delayBeforeTreatment) {
+        ApplicationBinder applicationBinder = ApplicationBinder.builder()
+                .clock(clock)
+                .period(Config.defaultServiceBindingRefresh)
+                .serviceInstanceId(serviceId)
+                .cloudFoundryApi(cloudFoundryApi)
+                .serviceRepository(serviceRepository)
+                .applicationRepository(applicationRepository)
+                .build();
+        applicationBinder.start(delayBeforeTreatment);
     }
 
 

--- a/src/main/java/org/cloudfoundry/autosleep/util/serializer/PatternDeserializer.java
+++ b/src/main/java/org/cloudfoundry/autosleep/util/serializer/PatternDeserializer.java
@@ -1,0 +1,21 @@
+package org.cloudfoundry.autosleep.util.serializer;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+public class PatternDeserializer extends JsonDeserializer<Pattern> {
+
+    @Override
+    public Pattern deserialize(JsonParser jp, DeserializationContext ctx) throws IOException {
+        try {
+            return Pattern.compile(jp.getValueAsString());
+        } catch (PatternSyntaxException p) {
+            throw new IOException("Invalid regexp", p);
+        }
+    }
+}

--- a/src/main/java/org/cloudfoundry/autosleep/util/serializer/PatternSerializer.java
+++ b/src/main/java/org/cloudfoundry/autosleep/util/serializer/PatternSerializer.java
@@ -1,0 +1,17 @@
+package org.cloudfoundry.autosleep.util.serializer;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+import java.util.regex.Pattern;
+
+public class PatternSerializer extends JsonSerializer<Pattern> {
+
+    @Override
+    public void serialize(Pattern pattern, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+            throws IOException {
+        jsonGenerator.writeString(pattern.pattern());
+    }
+}

--- a/src/main/resources/templates/views/admin/debug/applications.tpl
+++ b/src/main/resources/templates/views/admin/debug/applications.tpl
@@ -21,7 +21,7 @@ layout 'layouts/main.tpl',
         },
         mainBody: contents {
 
-            div(class: "row", id:"allApplications"){
+            div(id:"allApplications"){
 
             }
         }

--- a/src/main/resources/templates/views/admin/debug/bindings.tpl
+++ b/src/main/resources/templates/views/admin/debug/bindings.tpl
@@ -49,7 +49,7 @@ layout 'layouts/main.tpl',
                 }
             }
 
-            div(class: "row", id:"allServiceBindings"){
+            div(id:"allServiceBindings"){
 
             }
         }

--- a/src/main/resources/templates/views/admin/debug/instances.tpl
+++ b/src/main/resources/templates/views/admin/debug/instances.tpl
@@ -21,12 +21,12 @@ layout 'layouts/main.tpl',
         },
         mainBody: contents {
             div(class: "row"){
-                div(class: "col-xs-3"){
+                div(class: "col-xs-2"){
                     label("Organization Id : ")
                     br()
                     input(type:"text", id:"createServiceInstanceOrgGuid")
                 }
-                div(class: "col-xs-3"){
+                div(class: "col-xs-2"){
                     label("Space Id : ")
                     br()
                     input(type:"text", id:"createServiceInstanceSpaceGuid")
@@ -39,14 +39,20 @@ layout 'layouts/main.tpl',
                 div(class: "col-xs-2"){
                     label("Inactivity : ")
                     br()
-                    input(type:"text", id:"createServiceInstancInactivity")
+                    input(type:"text", id:"createServiceInstanceInactivity")
                 }
                 div(class: "col-xs-2"){
+                    label("Exclude names : ")
+                    br()
+                    input(type:"text", id:"createServiceInstanceExclusion")
+                }
+                div(class: "col-xs-2"){
+                    label("")
                     input(type:"submit", onclick:"helper.addServiceInstance(); return false;", value: "Add")
                 }
             }
 
-            div(class: "row", id:"allServiceInstances"){
+            div(id:"allServiceInstances"){
 
             }
         }

--- a/src/test/java/org/cloudfoundry/autosleep/admin/controller/DebugControllerTest.java
+++ b/src/test/java/org/cloudfoundry/autosleep/admin/controller/DebugControllerTest.java
@@ -8,6 +8,7 @@ import org.cloudfoundry.autosleep.dao.repositories.ApplicationRepository;
 import org.cloudfoundry.autosleep.dao.repositories.BindingRepository;
 import org.cloudfoundry.autosleep.dao.repositories.ServiceRepository;
 import org.cloudfoundry.autosleep.remote.ApplicationActivity;
+import org.cloudfoundry.autosleep.remote.ApplicationIdentity;
 import org.cloudfoundry.client.lib.domain.CloudApplication.AppState;
 import org.cloudfoundry.community.servicebroker.model.Catalog;
 import org.cloudfoundry.community.servicebroker.model.CreateServiceInstanceRequest;
@@ -20,6 +21,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -27,12 +29,18 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import java.nio.charset.Charset;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -73,22 +81,11 @@ public class DebugControllerTest {
         MockitoAnnotations.initMocks(this);
         mockMvc = MockMvcBuilders.standaloneSetup(debugController).build();
 
-        CreateServiceInstanceRequest createRequestTemplate = new CreateServiceInstanceRequest("definition",
-                "plan",
-                "org",
-                "space");
-        AutosleepServiceInstance serviceInstance = new AutosleepServiceInstance(
-                createRequestTemplate.withServiceInstanceId(serviceInstanceId));
-        ApplicationBinding serviceBinding = new ApplicationBinding(serviceBindingId, serviceInstanceId,
-                null, null, UUID.randomUUID().toString());
-        ApplicationInfo applicationInfo = new ApplicationInfo(applicationId).withRemoteInfo(new ApplicationActivity(
-                applicationId, "applicationName", AppState.STARTED, Instant.now(), Instant.now()));
+
         when(catalog.getServiceDefinitions()).thenReturn(Collections.singletonList(
                 new ServiceDefinition("serviceDefinitionId", "serviceDefinition", "", true,
                         Collections.singletonList(new Plan("planId", "plan", "")))));
-        when(serviceRepository.findAll()).thenReturn(Collections.singletonList(serviceInstance));
-        when(bindingRepository.findAll()).thenReturn(Collections.singletonList(serviceBinding));
-        when(applicationRepository.findAll()).thenReturn(Collections.singletonList(applicationInfo));
+
 
     }
 
@@ -113,11 +110,24 @@ public class DebugControllerTest {
 
     @Test
     public void testListInstances() throws Exception {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(AutosleepServiceInstance.INACTIVITY_PARAMETER, "PT15M");
+        parameters.put(AutosleepServiceInstance.EXCLUDE_PARAMETER, ".*");
+        CreateServiceInstanceRequest createRequestTemplate = new CreateServiceInstanceRequest("definition",
+                "plan",
+                "org",
+                "space", parameters);
+        AutosleepServiceInstance serviceInstance = new AutosleepServiceInstance(
+                createRequestTemplate.withServiceInstanceId(serviceInstanceId));
+        when(serviceRepository.findAll()).thenReturn(Collections.singletonList(serviceInstance));
+
+
         mockMvc.perform(get("/admin/debug/services/instances/").accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk()).andExpect(content()
                 .contentType(new MediaType(MediaType.APPLICATION_JSON,
                         Collections.singletonMap("charset", Charset.forName("UTF-8").toString()))))
                 .andDo(mvcResult -> {
+                    verify(serviceRepository, times(1)).findAll();
                     AutosleepServiceInstance[] serviceInstances = objectMapper
                             .readValue(mvcResult.getResponse().getContentAsString(), AutosleepServiceInstance[].class);
                     assertThat(serviceInstances.length, is(equalTo(1)));
@@ -127,32 +137,67 @@ public class DebugControllerTest {
 
     @Test
     public void testListBindings() throws Exception {
+        ApplicationBinding serviceBinding = new ApplicationBinding(serviceBindingId, serviceInstanceId,
+                null, null, UUID.randomUUID().toString());
+        when(bindingRepository.findAll()).thenReturn(Collections.singletonList(serviceBinding));
+
         mockMvc.perform(get("/admin/debug/services/bindings/" + serviceInstanceId)
                 .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk()).andExpect(content()
                 .contentType(new MediaType(MediaType.APPLICATION_JSON,
                         Collections.singletonMap("charset", Charset.forName("UTF-8").toString()))))
                 .andDo(mvcResult -> {
+                    verify(bindingRepository, times(1)).findAll();
                     ApplicationBinding[] serviceBindings = objectMapper
                             .readValue(mvcResult.getResponse().getContentAsString(), ApplicationBinding[].class);
                     assertThat(serviceBindings.length, is(equalTo(1)));
                     assertThat(serviceBindings[0].getId(), is(equalTo(serviceBindingId)));
-                });
-    }
 
-    @Test
-    public void testListApplications() throws Exception {
-        mockMvc.perform(get("/admin/debug/services/applications/")
+
+                });
+        mockMvc.perform(get("/admin/debug/services/bindings/" + serviceInstanceId + "-tmp")
                 .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk()).andExpect(content()
                 .contentType(new MediaType(MediaType.APPLICATION_JSON,
                         Collections.singletonMap("charset", Charset.forName("UTF-8").toString()))))
                 .andDo(mvcResult -> {
+                    verify(bindingRepository, times(2)).findAll();
+                    ApplicationBinding[] serviceBindings = objectMapper
+                            .readValue(mvcResult.getResponse().getContentAsString(), ApplicationBinding[].class);
+                    assertThat(serviceBindings.length, is(equalTo(0)));
+                });
+    }
+
+    @Test
+    public void testListApplications() throws Exception {
+        ApplicationInfo applicationInfo = new ApplicationInfo(applicationId).withRemoteInfo(new ApplicationActivity(
+                new ApplicationIdentity(applicationId, "applicationName"),
+                AppState.STARTED, Instant.now(), Instant.now()));
+        when(applicationRepository.findAll()).thenReturn(Collections.singletonList(applicationInfo));
+
+        mockMvc.perform(get("/admin/debug/services/applications/")
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content()
+                        .contentType(new MediaType(MediaType.APPLICATION_JSON,
+                                Collections.singletonMap("charset", Charset.forName("UTF-8").toString()))))
+                .andDo(mvcResult -> {
+                    verify(applicationRepository, times(1)).findAll();
                     ApplicationInfo[] applicationInfos = objectMapper
                             .readValue(mvcResult.getResponse().getContentAsString(), ApplicationInfo[].class);
                     assertThat(applicationInfos.length, is(equalTo(1)));
                     assertThat(applicationInfos[0].getUuid(), is(equalTo(applicationId)));
                 });
+    }
+
+    @Test
+    public void testDeleteApplication() throws Exception {
+        String applicationId = "applicationToDelete";
+        mockMvc.perform(delete("/admin/debug/services/applications/" + applicationId))
+                .andExpect(status().is(HttpStatus.NO_CONTENT.value()))
+                .andDo(mvcResult -> verify(applicationRepository, times(1)).delete(eq(applicationId)));
+
+
     }
 
 

--- a/src/test/java/org/cloudfoundry/autosleep/dao/model/ApplicationInfoTest.java
+++ b/src/test/java/org/cloudfoundry/autosleep/dao/model/ApplicationInfoTest.java
@@ -2,6 +2,7 @@ package org.cloudfoundry.autosleep.dao.model;
 
 import lombok.extern.slf4j.Slf4j;
 import org.cloudfoundry.autosleep.remote.ApplicationActivity;
+import org.cloudfoundry.autosleep.remote.ApplicationIdentity;
 import org.cloudfoundry.client.lib.domain.CloudApplication;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -72,7 +73,7 @@ public class ApplicationInfoTest {
     }
 
     private ApplicationActivity newApplicationActivity(Instant lastEvent, Instant lastLog) {
-        return new ApplicationActivity(appUuid, "appname",
+        return new ApplicationActivity(new ApplicationIdentity(appUuid, "appname"),
                 CloudApplication.AppState.STARTED, lastEvent, lastLog);
     }
 }

--- a/src/test/java/org/cloudfoundry/autosleep/dao/repositories/AppRepositoryTest.java
+++ b/src/test/java/org/cloudfoundry/autosleep/dao/repositories/AppRepositoryTest.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.cloudfoundry.autosleep.config.RepositoryConfig;
 import org.cloudfoundry.autosleep.dao.model.ApplicationInfo;
 import org.cloudfoundry.autosleep.remote.ApplicationActivity;
+import org.cloudfoundry.autosleep.remote.ApplicationIdentity;
 import org.cloudfoundry.client.lib.domain.CloudApplication.AppState;
 import org.junit.After;
 import org.junit.Before;
@@ -47,7 +48,9 @@ public abstract class AppRepositoryTest {
     }
 
     private ApplicationInfo buildAppInfo(UUID uuid) {
-        return new ApplicationInfo(uuid).withRemoteInfo(new ApplicationActivity(uuid, "appname", AppState.STARTED,
+        return new ApplicationInfo(uuid).withRemoteInfo(new ApplicationActivity(
+                new ApplicationIdentity(uuid, "appname"),
+                AppState.STARTED,
                 Instant.now(), Instant.now()));
     }
 

--- a/src/test/java/org/cloudfoundry/autosleep/dao/repositories/ServiceRepositoryTest.java
+++ b/src/test/java/org/cloudfoundry/autosleep/dao/repositories/ServiceRepositoryTest.java
@@ -14,9 +14,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -54,9 +57,11 @@ public abstract class  ServiceRepositoryTest {
      */
     @Before
     public void populateDao() {
-
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(AutosleepServiceInstance.INACTIVITY_PARAMETER, "PT15M");
+        parameters.put(AutosleepServiceInstance.EXCLUDE_PARAMETER, ".*");
         createRequestTemplate = new CreateServiceInstanceRequest(SERVICE_DEFINITION_ID, SERVICE_PLAN_ID, ORG_TEST,
-                SPACE_TEST);
+                SPACE_TEST, parameters);
 
         dao.deleteAll();
 
@@ -132,7 +137,7 @@ public abstract class  ServiceRepositoryTest {
                 is(equalTo(createRequestTemplate.getServiceDefinitionId())));
         assertThat(serviceInstance.getOrganizationGuid(), is(equalTo(ORG_TEST)));
         assertThat(serviceInstance.getSpaceGuid(), is(equalTo(SPACE_TEST)));
-        assertThat(serviceInstance.getInterval(), is(equalTo(Config.defaultInactivityPeriod)));
+        assertThat(serviceInstance.getInterval(), is(equalTo(Duration.ofMinutes(15))));
         assertTrue("Succeed in getting a service that does not exist", dao.findOne("testGetServiceFail") == null);
 
     }

--- a/src/test/java/org/cloudfoundry/autosleep/scheduling/ApplicationBinderTest.java
+++ b/src/test/java/org/cloudfoundry/autosleep/scheduling/ApplicationBinderTest.java
@@ -1,0 +1,156 @@
+package org.cloudfoundry.autosleep.scheduling;
+
+import lombok.AllArgsConstructor;
+import org.cloudfoundry.autosleep.dao.model.ApplicationInfo;
+import org.cloudfoundry.autosleep.dao.model.AutosleepServiceInstance;
+import org.cloudfoundry.autosleep.dao.repositories.ApplicationRepository;
+import org.cloudfoundry.autosleep.dao.repositories.ServiceRepository;
+import org.cloudfoundry.autosleep.remote.CloudFoundryApiService;
+import org.cloudfoundry.autosleep.remote.ApplicationIdentity;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ApplicationBinderTest {
+    private static final Duration INTERVAL = Duration.ofMillis(300);
+
+    private static final String SERVICE_ID = "serviceId";
+
+    private static final UUID SPACE_ID = UUID.randomUUID();
+
+    @AllArgsConstructor
+    private static class ListOfSizeMatcher<T> extends ArgumentMatcher<List<T>> {
+        private int expectedSize;
+
+        public boolean matches(Object list) {
+            return List.class.isInstance(list) && List.class.cast(list).size() == expectedSize;
+        }
+    }
+
+
+    @Mock
+    private Clock clock;
+
+    @Mock
+    private CloudFoundryApiService cloudFoundryApi;
+
+    @Mock
+    private ServiceRepository serviceRepository;
+
+    @Mock
+    private ApplicationRepository applicationRepository;
+
+    @Mock
+    private AutosleepServiceInstance autosleepServiceInstance;
+
+
+    private ApplicationBinder applicationBinder;
+
+    private List<UUID> remoteApplicationIds = Arrays.asList(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
+
+
+    @Before
+    public void buildMocks() {
+        //default
+        when(autosleepServiceInstance.getSpaceGuid()).thenReturn(SPACE_ID.toString());
+        when(autosleepServiceInstance.getServiceInstanceId()).thenReturn(SERVICE_ID);
+        when(serviceRepository.findOne(eq(SERVICE_ID))).thenReturn(autosleepServiceInstance);
+        when(cloudFoundryApi.listApplications(eq(SPACE_ID), any(Pattern.class)))
+                .thenReturn(remoteApplicationIds.stream()
+                        .map(applicationId -> new ApplicationIdentity(applicationId, applicationId.toString()))
+                        .collect(Collectors.toList()));
+
+
+        applicationBinder = spy(ApplicationBinder.builder()
+                .clock(clock)
+                .period(INTERVAL)
+                .serviceInstanceId(SERVICE_ID)
+                .cloudFoundryApi(cloudFoundryApi)
+                .serviceRepository(serviceRepository)
+                .applicationRepository(applicationRepository)
+                .build());
+
+    }
+
+
+    @Test
+    public void testNewAppeared() throws Exception {
+        when(serviceRepository.findOne(eq(SERVICE_ID))).thenReturn(autosleepServiceInstance);
+        when(autosleepServiceInstance.getExcludeNames()).thenReturn(null);
+        //it will return every ids except final one
+        when(applicationRepository.findAll()).thenReturn(remoteApplicationIds.stream()
+                .filter(applicationId ->
+                        !applicationId.equals(remoteApplicationIds.get(remoteApplicationIds.size() - 1)))
+                .map(ApplicationInfo::new)
+                .collect(Collectors.toList()));
+        applicationBinder.run();
+
+        verify(applicationBinder, times(1)).rescheduleWithDefaultPeriod();
+        verify(cloudFoundryApi, times(1)).listApplications(eq(SPACE_ID), eq(null));
+        verify(cloudFoundryApi, times(1))
+                .bindServiceInstance(argThat(anyListOfSize(1, ApplicationIdentity.class)), anyString());
+
+        Pattern pattern = Pattern.compile(".*");
+        when(autosleepServiceInstance.getExcludeNames()).thenReturn(pattern);
+        applicationBinder.run();
+        verify(cloudFoundryApi, times(1)).listApplications(eq(SPACE_ID), eq(pattern));
+
+    }
+
+    @Test
+    public void testNoNew() throws Exception {
+        when(serviceRepository.findOne(eq(SERVICE_ID))).thenReturn(autosleepServiceInstance);
+        //it will return every ids except final one
+        when(applicationRepository.findAll()).thenReturn(remoteApplicationIds.stream()
+                .map(ApplicationInfo::new)
+                .collect(Collectors.toList()));
+        applicationBinder.run();
+
+        verify(applicationBinder, times(1)).rescheduleWithDefaultPeriod();
+        verify(cloudFoundryApi, never())
+                .bindServiceInstance(anyListOf(ApplicationIdentity.class), anyString());
+
+    }
+
+    @Test
+    public void testRunServiceDeleted() {
+        when(serviceRepository.findOne(eq(SERVICE_ID))).thenReturn(null);
+        applicationBinder.run();
+        verify(clock, times(1)).removeTask(eq(SERVICE_ID));
+        verify(applicationBinder, never()).rescheduleWithDefaultPeriod();
+    }
+
+
+    private <T> ArgumentMatcher<List<T>> anyListOfSize(final int expectedSize, Class<T> objectClass) {
+        return new ArgumentMatcher<List<T>>() {
+            @Override
+            public boolean matches(Object object) {
+                return List.class.isInstance(object) && List.class.cast(object).size() == expectedSize;
+            }
+        };
+    }
+
+
+}

--- a/src/test/java/org/cloudfoundry/autosleep/scheduling/ClockTest.java
+++ b/src/test/java/org/cloudfoundry/autosleep/scheduling/ClockTest.java
@@ -28,7 +28,6 @@ public class ClockTest {
     private static final Duration PERIOD = Duration.ofMillis(200);
     private static final String TEST_ID = "93847";
 
-    @Autowired
     protected Clock clock = new Clock();
 
     @Mock
@@ -49,7 +48,7 @@ public class ClockTest {
     @Test
     public void testStartTask() throws Exception {
         clock.scheduleTask(TEST_ID, PERIOD, runnable);
-        Thread.sleep(PERIOD.toMillis() / 2);
+        Thread.sleep(PERIOD.dividedBy(3).toMillis());
         verify(runnable, never()).run();
         Thread.sleep(PERIOD.toMillis());
         verify(runnable, times(1)).run();


### PR DESCRIPTION
- CloudFoundryApi: Implementation of bindServiceInstance
- AutosleepServiceInstanceService: list of applications of the instanciated space, then call the new implemented method bindServiceInstance
- Add tests on bindServiceInstance
- Update space on bindServiceInstance
- Update of application remote information by app checker
- Corrections on debug ihm
- Add delete application on ihm
- Add task that bind applications every 24 hours
- add exclude names parameter
- add noOptOut parameter (not on IHM for now)

**Missing currently:**
- acceptance tests: need to clarify how to check that the binding his done (instead of grep on `cf services` call? Or maybe using a _regexp_?
