### PR TITLE
Add acceptance test for autobind & filtering on current application

### DIFF
--- a/acceptance/3_application_unbind.robot
+++ b/acceptance/3_application_unbind.robot
@@ -5,8 +5,9 @@ Force Tags      Service broker
 Test Teardown   Run Keywords  Delete service instance
 
 *** Variables ***
-${INACTIVITY}  PT30S
 ${INACTIVITY_IN_S}  30
+${INACTIVITY}  PT${INACTIVITY_IN_S}S
+
 
 *** Test Cases ***
 

--- a/acceptance/4_application_autobind.robot
+++ b/acceptance/4_application_autobind.robot
@@ -13,18 +13,15 @@ ${INACTIVITY}  PT${INACTIVITY_IN_S}S
 1) Automatically bind application by service instance
     [Documentation]     Check that app is automatically bound by service instance
     Clean
-    ${regex} 					Catenate   SEPARATOR=  	^(?:(?!    ${TESTED_APP_NAME}   ).)*$
-	Create service instance		${INACTIVITY}    ${regex}
-	Sleep               		15
-	Check App Binded
+    ${regex}                  Catenate   SEPARATOR=      ^(?:(?!    ${TESTED_APP_NAME}   ).)*$
+    Create service instance   ${INACTIVITY}    ${regex}
+    Sleep                     15
+    Check App Bound
 
 
 2) Service does not bind ignored applications
-	[Documentation]		Check that no application is bound by the service instance
-	Clean
-	Create service instance		${INACTIVITY}
-	Sleep						15
-	Check No App Binded
-
-
-
+    [Documentation]        Check that no application is bound by the service instance
+    Clean
+    Create service instance  ${INACTIVITY}
+    Sleep                    15
+    Check No App Bound

--- a/acceptance/4_application_autobind.robot
+++ b/acceptance/4_application_autobind.robot
@@ -1,0 +1,30 @@
+*** Settings ***
+Resource        Keywords.robot
+Documentation   Test if application autobound is stopped
+Force Tags      Service broker
+Test Teardown   Run Keywords  Clean
+
+*** Variables ***
+${INACTIVITY_IN_S}  30
+${INACTIVITY}  PT${INACTIVITY_IN_S}S
+
+*** Test Cases ***
+
+1) Automatically bind application by service instance
+    [Documentation]     Check that app is automatically bound by service instance
+    Clean
+    ${regex} 					Catenate   SEPARATOR=  	^(?:(?!    ${TESTED_APP_NAME}   ).)*$
+	Create service instance		${INACTIVITY}    ${regex}
+	Sleep               		15
+	Check App Binded
+
+
+2) Service does not bind ignored applications
+	[Documentation]		Check that no application is bound by the service instance
+	Clean
+	Create service instance		${INACTIVITY}
+	Sleep						15
+	Check No App Binded
+
+
+

--- a/acceptance/Keywords.robot
+++ b/acceptance/Keywords.robot
@@ -36,15 +36,15 @@ Unbind service instance
     Should Be Equal As Integers  ${result.rc}    0
     [Return]                    ${result.rc}
 
-Check App Binded
-	[Documentation]				Return true if app is binded to the service
+Check App Bound
+	[Documentation]				Return true if app is bound to the service
 	${regex} 					Set Variable 	${SERVICE_INSTANCE_NAME} *autosleep *default.* (${TESTED_APP_NAME}[ ,]).*
 	Log 						${regex}
 	${result} =                 Run Process  cf  services
 	Should Match Regexp			${result.stdout}  ${regex}
 
-Check No App Binded
-	[Documentation]				Return true if app is binded to the service
+Check No App Bound
+	[Documentation]				Return true if app is bound to the service
 	${regex} 					Set Variable 	${SERVICE_INSTANCE_NAME} *autosleep *default * create
 	Log 						${regex}
 	${result} =                 Run Process  cf  services

--- a/acceptance/Keywords.robot
+++ b/acceptance/Keywords.robot
@@ -5,16 +5,19 @@ Library         Process
 *** Variables ***
 ${TESTED_APP_NAME}  static_test
 ${SERVICE_INSTANCE_NAME}  my-autosleep-acc
-${DEFAULT_INACTIVITY}  PT20S
 ${DEFAULT_INACTIVITY_IN_S}  20
+${DEFAULT_INACTIVITY}  PT${DEFAULT_INACTIVITY_IN_S}S
+${EXCLUDE_APP_NAMES}  .*
 # Sometimes app instance aren't well synchronize. ${INACTIVITY_BUFFER_IN_S} will be added after inactivity, before checking anything
 ${INACTIVITY_BUFFER_IN_S}  20
+
+
 
 *** Keywords ***
 Create service instance
     [Documentation]             Create a service instance, checking that it doesn't fail
-	[Arguments]                 ${inactivity}=${DEFAULT_INACTIVITY}
-	${result} =                 Run Process  cf  cs  autosleep  default  ${SERVICE_INSTANCE_NAME}  -c  {"inactivity": "${inactivity}"}
+	[Arguments]                 ${inactivity}=${DEFAULT_INACTIVITY}  ${exclude_app_names}=${EXCLUDE_APP_NAMES}
+	${result} =                 Run Process  cf  cs  autosleep  default  ${SERVICE_INSTANCE_NAME}  -c  {"inactivity": "${inactivity}", "excludeAppNameRegExp" : "${exclude_app_names}"}
 	Should Not Contain          ${result.stdout}    FAIL
 	Should Be Equal As Integers    ${result.rc}    0
 	[Return]                    ${result.rc}
@@ -32,6 +35,20 @@ Unbind service instance
 	Should Not Contain          ${result.stdout}    FAIL
     Should Be Equal As Integers  ${result.rc}    0
     [Return]                    ${result.rc}
+
+Check App Binded
+	[Documentation]				Return true if app is binded to the service
+	${regex} 					Set Variable 	${SERVICE_INSTANCE_NAME} *autosleep *default.* (${TESTED_APP_NAME}[ ,]).*
+	Log 						${regex}
+	${result} =                 Run Process  cf  services
+	Should Match Regexp			${result.stdout}  ${regex}
+
+Check No App Binded
+	[Documentation]				Return true if app is binded to the service
+	${regex} 					Set Variable 	${SERVICE_INSTANCE_NAME} *autosleep *default * create
+	Log 						${regex}
+	${result} =                 Run Process  cf  services
+	Should Match Regexp			${result.stdout}  ${regex}
 
 Delete service instance
     [Documentation]             Delete base service instance, checking it doesn't fail

--- a/src/main/java/org/cloudfoundry/autosleep/config/DeployedApplicationConfig.java
+++ b/src/main/java/org/cloudfoundry/autosleep/config/DeployedApplicationConfig.java
@@ -1,0 +1,64 @@
+package org.cloudfoundry.autosleep.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+
+import javax.annotation.PostConstruct;
+import java.io.IOException;
+
+@Configuration
+@Slf4j
+public class DeployedApplicationConfig {
+    static final String APPLICATION_DESCRIPTION_ENVIRONMENT_KEY = "VCAP_APPLICATION";
+
+    @Autowired
+    private Environment environment;
+
+
+    @PostConstruct
+    public void init() {
+        log.debug("VCAP_APPLICATION={}", environment.getProperty(APPLICATION_DESCRIPTION_ENVIRONMENT_KEY));
+    }
+
+    @Bean
+    public Deployment loadCurrentDeployment() throws IOException {
+        String deployment = environment.getProperty(APPLICATION_DESCRIPTION_ENVIRONMENT_KEY);
+        if (deployment == null) {
+            return null;
+        } else {
+            ObjectMapper objectMapper = new ObjectMapper();
+            return objectMapper.readValue(deployment, Deployment.class);
+        }
+    }
+
+    /*
+    VCAP_APPLICATION={"limits":{"mem":1024,"disk":1024,"fds":16384},
+    "application_id":"3048d795-f031-435f-85e8-71dce339e869",
+    "application_version":"b546c9d4-8885-4d50-a855-490ddb5b5a1c",
+
+    "application_name":"autosleep-app",
+    "application_uris":["autosleep-app-ben.cf.ns.nd-paas.itn.ftgroup","autosleep-nonnational-artotype.cf.ns.nd-paas
+    .itn.ftgroup","autosleep.cf.ns.nd-paas.itn.ftgroup"],
+    "version":"b546c9d4-8885-4d50-a855-490ddb5b5a1c",
+    "name":"autosleep-app",
+    "space_name":"autosleep"
+    ,"space_id":"2d745a4b-67e3-4398-986e-2adbcf8f7ec9",
+    "uris":["autosleep-app-ben.cf.ns.nd-paas.itn.ftgroup",
+    "autosleep-nonnational-artotype.cf.ns.nd-paas.itn.ftgroup",
+    "autosleep.cf.ns.nd-paas.itn.ftgroup"]
+    ,"users":null,
+    "instance_id":"7984a682cab9447891674f862299c77f",
+    "instance_index":0,
+    "host":"0.0.0.0",
+    "port":61302,
+    "started_at":"2015-11-18 15:49:06 +0000",
+    "started_at_timestamp":1447861746,
+    "start":"2015-11-18 15:49:06 +0000",
+    "state_timestamp":1447861746
+    }
+     */
+}

--- a/src/main/java/org/cloudfoundry/autosleep/config/Deployment.java
+++ b/src/main/java/org/cloudfoundry/autosleep/config/Deployment.java
@@ -1,0 +1,21 @@
+package org.cloudfoundry.autosleep.config;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Deployment {
+    @JsonProperty("application_id")
+    private UUID applicationId;
+
+    @JsonProperty("application_name")
+    private String applicationName;
+
+
+}

--- a/src/main/java/org/cloudfoundry/autosleep/scheduling/GlobalWatcher.java
+++ b/src/main/java/org/cloudfoundry/autosleep/scheduling/GlobalWatcher.java
@@ -2,6 +2,7 @@ package org.cloudfoundry.autosleep.scheduling;
 
 import lombok.extern.slf4j.Slf4j;
 import org.cloudfoundry.autosleep.config.Config;
+import org.cloudfoundry.autosleep.config.Deployment;
 import org.cloudfoundry.autosleep.dao.model.ApplicationBinding;
 import org.cloudfoundry.autosleep.dao.repositories.ApplicationRepository;
 import org.cloudfoundry.autosleep.dao.repositories.BindingRepository;
@@ -28,17 +29,21 @@ public class GlobalWatcher {
 
     private CloudFoundryApiService cloudFoundryApi;
 
+    private Deployment deployment;
+
 
     @Autowired
     public GlobalWatcher(Clock clock, BindingRepository bindingRepository,
                          ServiceRepository serviceRepository, ApplicationRepository applicationRepository,
-                         CloudFoundryApiService cloudFoundryApi) {
+                         CloudFoundryApiService cloudFoundryApi,
+                         Deployment deployment) {
         this.clock = clock;
         this.cloudFoundryApi = cloudFoundryApi;
         this.bindingRepository = bindingRepository;
         this.serviceRepository = serviceRepository;
         this.applicationRepository = applicationRepository;
         this.cloudFoundryApi = cloudFoundryApi;
+        this.deployment = deployment;
     }
 
     @PostConstruct
@@ -73,6 +78,7 @@ public class GlobalWatcher {
                 .cloudFoundryApi(cloudFoundryApi)
                 .serviceRepository(serviceRepository)
                 .applicationRepository(applicationRepository)
+                .deployment(deployment)
                 .build();
         applicationBinder.start(delayBeforeTreatment);
     }

--- a/src/test/java/org/cloudfoundry/autosleep/ApplicationTest.java
+++ b/src/test/java/org/cloudfoundry/autosleep/ApplicationTest.java
@@ -37,6 +37,5 @@ public class ApplicationTest {
 
     @Test
     public void testDummy() {
-
     }
 }

--- a/src/test/java/org/cloudfoundry/autosleep/config/DeployedApplicationConfigTest.java
+++ b/src/test/java/org/cloudfoundry/autosleep/config/DeployedApplicationConfigTest.java
@@ -1,0 +1,72 @@
+package org.cloudfoundry.autosleep.config;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.core.env.Environment;
+
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DeployedApplicationConfigTest {
+
+    private static final UUID APP_ID = UUID.randomUUID();
+
+    @Mock
+    private Environment environment;
+
+    @InjectMocks
+    private DeployedApplicationConfig config;
+
+    @Test
+    public void testLoadCurrentDeployment() throws Exception {
+        when(environment.getProperty(eq(DeployedApplicationConfig.APPLICATION_DESCRIPTION_ENVIRONMENT_KEY)))
+                .thenReturn(null);
+        Deployment deployment = config.loadCurrentDeployment();
+        assertThat(deployment, is(nullValue()));
+
+        when(environment.getProperty(eq(DeployedApplicationConfig.APPLICATION_DESCRIPTION_ENVIRONMENT_KEY)))
+                .thenReturn(getSampleVcapApplication());
+        deployment = config.loadCurrentDeployment();
+        assertThat(deployment, is(notNullValue()));
+        assertThat(deployment.getApplicationId(), is(equalTo(APP_ID)));
+
+    }
+
+    private String getSampleVcapApplication() {
+        return "{\"limits\":{\"mem\":1024,\"disk\":1024,\"fds\":16384}," +
+                "\"application_id\":\"" + APP_ID.toString() + "\"," +
+                "\"application_version\":\"b546c9d4-8885-4d50-a855-490ddb5b5a1c\"," +
+                "\"application_name\":\"autosleep-app\"," +
+                "\"application_uris\":[\"autosleep-app-ben.cf.ns.nd-paas.itn.ftgroup\"," +
+                "\"autosleep-nonnational-artotype.cf.ns.nd-paas.itn.ftgroup\"," +
+                "\"autosleep.cf.ns.nd-paas.itn.ftgroup\"]," +
+                " \"version\":\"b546c9d4-8885-4d50-a855-490ddb5b5a1c\"," +
+                "\"name\":\"autosleep-app\"," +
+                "\"space_name\":\"autosleep\"" +
+                ",\"space_id\":\"2d745a4b-67e3-4398-986e-2adbcf8f7ec9\"," +
+                "\"uris\":[\"autosleep-app-ben.cf.ns.nd-paas.itn.ftgroup\"," +
+                "\"autosleep-nonnational-artotype.cf.ns.nd-paas.itn.ftgroup\"," +
+                "\"autosleep.cf.ns.nd-paas.itn.ftgroup\"]" +
+                ",\"users\":null," +
+                "\"instance_id\":\"7984a682cab9447891674f862299c77f\"," +
+                "\"instance_index\":0," +
+                "\"host\":\"0.0.0.0\"," +
+                "\"port\":61302," +
+                "\"started_at\":\"2015-11-18 15:49:06 +0000\"," +
+                "\"started_at_timestamp\":1447861746," +
+                "\"start\":\"2015-11-18 15:49:06 +0000\"," +
+                "\"state_timestamp\":1447861746" +
+                "}";
+    }
+}

--- a/src/test/java/org/cloudfoundry/autosleep/scheduling/GlobalWatcherTest.java
+++ b/src/test/java/org/cloudfoundry/autosleep/scheduling/GlobalWatcherTest.java
@@ -1,6 +1,7 @@
 package org.cloudfoundry.autosleep.scheduling;
 
 import lombok.extern.slf4j.Slf4j;
+import org.cloudfoundry.autosleep.config.Deployment;
 import org.cloudfoundry.autosleep.dao.model.ApplicationBinding;
 import org.cloudfoundry.autosleep.dao.model.AutosleepServiceInstance;
 import org.cloudfoundry.autosleep.dao.repositories.ApplicationRepository;
@@ -58,6 +59,9 @@ public class GlobalWatcherTest {
 
     @Mock
     private CloudFoundryApiService cloudFoundryApi;
+
+    @Mock
+    private Deployment deployment;
 
     @InjectMocks
     @Spy


### PR DESCRIPTION
- By default create service instance create a service that ignore all apps
- add test that filter every application except the monitored one: assert that it is binded at the end
- add test that check that a service instance that ignore every application does not bind any application
- add filtering on current application loaded from environment
