### PR TITLE
Add a 'secret' parameter

### DIFF
--- a/src/main/java/org/cloudfoundry/autosleep/servicebroker/service/AutoSleepServiceInstanceService.java
+++ b/src/main/java/org/cloudfoundry/autosleep/servicebroker/service/AutoSleepServiceInstanceService.java
@@ -43,7 +43,7 @@ public class AutoSleepServiceInstanceService implements ServiceInstanceService {
         log.debug("createServiceInstance - {}", request.getServiceInstanceId());
 
         AutosleepServiceInstance serviceInstance = serviceRepository.findOne(request.getServiceInstanceId());
-        if (serviceRepository.findOne(request.getServiceInstanceId()) != null) {
+        if (serviceInstance != null) {
             throw new ServiceInstanceExistsException(serviceInstance);
         } else {
             serviceInstance = new AutosleepServiceInstance(request);
@@ -66,12 +66,12 @@ public class AutoSleepServiceInstanceService implements ServiceInstanceService {
             UpdateServiceInstanceRequest request) throws
             ServiceInstanceUpdateNotSupportedException, ServiceBrokerException, ServiceInstanceDoesNotExistException {
         String serviceId = request.getServiceInstanceId();
-        log.debug("updateServiceInstance - {}", serviceId);
+        log.debug("updateParams - {}", serviceId);
         AutosleepServiceInstance serviceInstance = serviceRepository.findOne(serviceId);
         if (serviceInstance == null) {
             throw new ServiceInstanceDoesNotExistException(serviceId);
         } else {
-            serviceInstance = new AutosleepServiceInstance(request);
+            serviceInstance.updateFromRequest(request);
             serviceRepository.save(serviceInstance);
         }
         return serviceInstance;

--- a/src/test/java/org/cloudfoundry/autosleep/servicebroker/service/AutosleepServiceInstanceServiceTest.java
+++ b/src/test/java/org/cloudfoundry/autosleep/servicebroker/service/AutosleepServiceInstanceServiceTest.java
@@ -10,6 +10,7 @@ import org.cloudfoundry.autosleep.remote.ApplicationIdentity;
 import org.cloudfoundry.autosleep.scheduling.GlobalWatcher;
 import org.cloudfoundry.community.servicebroker.exception.ServiceInstanceDoesNotExistException;
 import org.cloudfoundry.community.servicebroker.exception.ServiceInstanceExistsException;
+import org.cloudfoundry.community.servicebroker.exception.ServiceInstanceUpdateNotSupportedException;
 import org.cloudfoundry.community.servicebroker.model.CreateServiceInstanceRequest;
 import org.cloudfoundry.community.servicebroker.model.DeleteServiceInstanceRequest;
 import org.cloudfoundry.community.servicebroker.model.ServiceInstance;
@@ -82,8 +83,7 @@ public class AutosleepServiceInstanceServiceTest {
                 ORG_TEST.toString(), SPACE_TEST.toString());
         createRequest.withServiceInstanceId(SERVICE_INSTANCE_ID);
 
-        updateRequest = new UpdateServiceInstanceRequest(SERVICE_DEFINITION_ID);
-        updateRequest.withInstanceId(SERVICE_INSTANCE_ID);
+        updateRequest = new UpdateServiceInstanceRequest(PLAN_ID).withInstanceId(SERVICE_INSTANCE_ID);
 
         deleteRequest = new DeleteServiceInstanceRequest(SERVICE_INSTANCE_ID, SERVICE_DEFINITION_ID, PLAN_ID);
 
@@ -141,6 +141,17 @@ public class AutosleepServiceInstanceServiceTest {
             log.debug("{} occurred as expected", e.getClass().getSimpleName());
         }
         when(serviceRepository.findOne(SERVICE_INSTANCE_ID)).thenReturn(new AutosleepServiceInstance(createRequest));
+
+
+        UpdateServiceInstanceRequest changePlanRequest = new UpdateServiceInstanceRequest(PLAN_ID+"_other")
+                .withInstanceId(SERVICE_INSTANCE_ID);
+        try {
+            instanceService.updateServiceInstance(changePlanRequest);
+            fail("not supposed to be able to change plan");
+        } catch (ServiceInstanceUpdateNotSupportedException e) {
+            log.debug("{} occurred as expected", e.getClass().getSimpleName());
+        }
+
         instanceService.updateServiceInstance(updateRequest);
         verify(serviceRepository, times(1)).save(any(AutosleepServiceInstance.class));
 


### PR DESCRIPTION
Add secret parameter, necessary to change 'protected' params of the services (for now only 'no-optout'). Accecptance tests will be added when pull request #61 is merged
