### PR TITLE
FIX #113: service raise error when parameter unknown

### DIFF
--- a/src/main/java/org/cloudfoundry/autosleep/servicebroker/service/parameters/ParameterReader.java
+++ b/src/main/java/org/cloudfoundry/autosleep/servicebroker/service/parameters/ParameterReader.java
@@ -2,13 +2,11 @@ package org.cloudfoundry.autosleep.servicebroker.service.parameters;
 
 import org.cloudfoundry.autosleep.servicebroker.service.InvalidParameterException;
 
-import java.util.Map;
-
 
 public interface ParameterReader<T> {
 
     String getParameterName();
 
-    T readParameter(Map<String, Object> parameters, boolean withDefault) throws InvalidParameterException;
+    T readParameter(Object parameter, boolean withDefault) throws InvalidParameterException;
 
 }

--- a/src/main/java/org/cloudfoundry/autosleep/servicebroker/service/parameters/ParameterReaderFactory.java
+++ b/src/main/java/org/cloudfoundry/autosleep/servicebroker/service/parameters/ParameterReaderFactory.java
@@ -10,6 +10,7 @@ import java.time.Duration;
 import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Objects;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
@@ -28,10 +29,10 @@ public class ParameterReaderFactory {
             }
 
             @Override
-            public Duration readParameter(Map<String, Object> parameters, boolean withDefault) throws
+            public Duration readParameter(Object parameter, boolean withDefault) throws
                     InvalidParameterException {
-                if (parameters.get(Config.ServiceInstanceParameters.IDLE_DURATION) != null) {
-                    String inactivityPattern = (String) parameters.get(Config.ServiceInstanceParameters.IDLE_DURATION);
+                if (parameter != null) {
+                    String inactivityPattern = (String) parameter;
                     log.debug("pattern " + inactivityPattern);
                     try {
                         return Duration.parse(inactivityPattern);
@@ -61,11 +62,10 @@ public class ParameterReaderFactory {
             }
 
             @Override
-            public Pattern readParameter(Map<String, Object> parameters, boolean withDefault) throws
+            public Pattern readParameter(Object parameter, boolean withDefault) throws
                     InvalidParameterException {
-                if (parameters.get(Config.ServiceInstanceParameters.EXCLUDE_FROM_AUTO_ENROLLMENT) != null) {
-                    String excludeNamesStr = (String) parameters.get(Config.ServiceInstanceParameters
-                            .EXCLUDE_FROM_AUTO_ENROLLMENT);
+                if (parameter != null) {
+                    String excludeNamesStr = (String) parameter;
                     if (!excludeNamesStr.trim().equals("")) {
                         log.debug("excludeFromAutoEnrollment " + excludeNamesStr);
                         try {
@@ -95,11 +95,11 @@ public class ParameterReaderFactory {
             }
 
             @Override
-            public Config.ServiceInstanceParameters.Enrollment readParameter(Map<String, Object> parameters, boolean
+            public Config.ServiceInstanceParameters.Enrollment readParameter(Object parameter, boolean
                     withDefault) throws
                     InvalidParameterException {
-                if (parameters.get(Config.ServiceInstanceParameters.AUTO_ENROLLMENT) != null) {
-                    String autoEnrollment = (String) parameters.get(Config.ServiceInstanceParameters.AUTO_ENROLLMENT);
+                if (parameter != null) {
+                    String autoEnrollment = (String) parameter;
                     log.debug("forcedAutoEnrollment " + autoEnrollment);
                     try {
                         return Config.ServiceInstanceParameters.Enrollment.valueOf(autoEnrollment);
@@ -132,11 +132,10 @@ public class ParameterReaderFactory {
             }
 
             @Override
-            public String readParameter(Map<String, Object> parameters, boolean withDefault) throws
+            public String readParameter(Object parameter, boolean withDefault) throws
                     InvalidParameterException {
-                Object receivedSecret = parameters.get(Config.ServiceInstanceParameters.SECRET);
-                if (receivedSecret != null) {
-                    return String.class.cast(receivedSecret);
+                if (parameter != null) {
+                    return String.class.cast(parameter);
                 } else {
                     return null;
                 }

--- a/src/test/java/org/cloudfoundry/autosleep/servicebroker/service/parameters/ParameterReaderFactoryTest.java
+++ b/src/test/java/org/cloudfoundry/autosleep/servicebroker/service/parameters/ParameterReaderFactoryTest.java
@@ -5,19 +5,15 @@ import org.cloudfoundry.autosleep.servicebroker.service.InvalidParameterExceptio
 import org.junit.Test;
 
 import java.time.Duration;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.regex.Pattern;
 
+import static org.cloudfoundry.autosleep.util.TestUtils.verifyThrown;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.*;
-
-import static org.hamcrest.Matchers.is;
-
-
-import static org.cloudfoundry.autosleep.util.TestUtils.verifyThrown;
+import static org.junit.Assert.assertThat;
 
 public class ParameterReaderFactoryTest {
 
@@ -29,14 +25,14 @@ public class ParameterReaderFactoryTest {
         assertThat(idleDurationReader.getParameterName(), is(equalTo(Config.ServiceInstanceParameters.IDLE_DURATION)));
 
         //default case
-        assertThat(idleDurationReader.readParameter(Collections.emptyMap(), true),
+        assertThat(idleDurationReader.readParameter(null, true),
                 is(equalTo(Config.DEFAULT_INACTIVITY_PERIOD)));
-        assertThat(idleDurationReader.readParameter(Collections.emptyMap(), false),
+        assertThat(idleDurationReader.readParameter(null, false),
                 is(nullValue()));
 
         //bad syntax
         verifyThrown(() -> idleDurationReader
-                        .readParameter(Collections.singletonMap(Config.ServiceInstanceParameters.IDLE_DURATION, "12"),
+                        .readParameter("12",
                                 true),
                 InvalidParameterException.class,
                 parameterChecked ->
@@ -44,9 +40,7 @@ public class ParameterReaderFactoryTest {
                                 is(equalTo(Config.ServiceInstanceParameters.IDLE_DURATION))));
 
         //good syntax
-        assertThat(idleDurationReader
-                .readParameter(Collections.singletonMap(Config.ServiceInstanceParameters.IDLE_DURATION, "PT12M"),
-                        true), is(equalTo(Duration.ofMinutes(12))));
+        assertThat(idleDurationReader.readParameter("PT12M", true), is(equalTo(Duration.ofMinutes(12))));
 
     }
 
@@ -58,15 +52,14 @@ public class ParameterReaderFactoryTest {
         assertThat(enrollmentParameterReader.getParameterName(),
                 is(equalTo(Config.ServiceInstanceParameters.AUTO_ENROLLMENT)));
         //default case are null
-        assertThat(enrollmentParameterReader.readParameter(Collections.emptyMap(), true),
+        assertThat(enrollmentParameterReader.readParameter(null, true),
                 is(Config.ServiceInstanceParameters.Enrollment.standard));
-        assertThat(enrollmentParameterReader.readParameter(Collections.emptyMap(), false),
+        assertThat(enrollmentParameterReader.readParameter(null, false),
                 is(nullValue()));
 
         //bad syntax is well thrown
         verifyThrown(() -> enrollmentParameterReader
-                        .readParameter(Collections.singletonMap(Config.ServiceInstanceParameters.AUTO_ENROLLMENT,
-                                "fart"), true),
+                        .readParameter("fart", true),
                 InvalidParameterException.class,
                 parameterChecked ->
                         assertThat(parameterChecked.getParameterName(),
@@ -74,13 +67,11 @@ public class ParameterReaderFactoryTest {
 
         //good syntax
         Config.ServiceInstanceParameters.Enrollment enrollment = enrollmentParameterReader
-                .readParameter(Collections.singletonMap(Config.ServiceInstanceParameters.AUTO_ENROLLMENT, Config
-                        .ServiceInstanceParameters.Enrollment.standard.name()), true);
+                .readParameter(Config.ServiceInstanceParameters.Enrollment.standard.name(), true);
         assertThat(enrollment, is(equalTo(Config
                 .ServiceInstanceParameters.Enrollment.standard)));
         enrollment = enrollmentParameterReader
-                .readParameter(Collections.singletonMap(Config.ServiceInstanceParameters.AUTO_ENROLLMENT, Config
-                        .ServiceInstanceParameters.Enrollment.forced.name()), false);
+                .readParameter(Config.ServiceInstanceParameters.Enrollment.forced.name(), false);
         assertThat(enrollment, is(equalTo(Config
                 .ServiceInstanceParameters.Enrollment.forced)));
     }
@@ -93,19 +84,16 @@ public class ParameterReaderFactoryTest {
                 is(equalTo(Config.ServiceInstanceParameters.EXCLUDE_FROM_AUTO_ENROLLMENT)));
 
         //default case are null
-        assertThat(excludeFromAutoEnrollmentReader.readParameter(Collections.emptyMap(), false),
+        assertThat(excludeFromAutoEnrollmentReader.readParameter(null, false),
                 is(nullValue()));
-        assertThat(excludeFromAutoEnrollmentReader.readParameter(Collections.singletonMap(Config
-                        .ServiceInstanceParameters.EXCLUDE_FROM_AUTO_ENROLLMENT, ""), false),
+        assertThat(excludeFromAutoEnrollmentReader.readParameter("", false),
                 is(nullValue()));
-        assertThat(excludeFromAutoEnrollmentReader.readParameter(Collections.emptyMap(), false),
+        assertThat(excludeFromAutoEnrollmentReader.readParameter(null, false),
                 is(nullValue()));
 
         //bad syntax is well thrown
         verifyThrown(() -> excludeFromAutoEnrollmentReader
-                        .readParameter(Collections
-                                        .singletonMap(Config.ServiceInstanceParameters.EXCLUDE_FROM_AUTO_ENROLLMENT,
-                                                "*"),
+                        .readParameter("*",
                                 true),
                 InvalidParameterException.class,
                 parameterChecked ->
@@ -113,9 +101,7 @@ public class ParameterReaderFactoryTest {
                                 is(equalTo(Config.ServiceInstanceParameters.EXCLUDE_FROM_AUTO_ENROLLMENT))));
 
         String pattern = ".*";
-        Pattern result = excludeFromAutoEnrollmentReader
-                .readParameter(Collections.singletonMap(Config.ServiceInstanceParameters.EXCLUDE_FROM_AUTO_ENROLLMENT,
-                        pattern), true);
+        Pattern result = excludeFromAutoEnrollmentReader.readParameter(pattern, true);
         assertThat(result, is(not(nullValue())));
         assertThat(result.pattern(), is(equalTo(pattern)));
     }
@@ -126,12 +112,10 @@ public class ParameterReaderFactoryTest {
         assertThat(secretReader.getParameterName(), is(equalTo(Config.ServiceInstanceParameters.SECRET)));
 
         //default case are null
-        assertThat(secretReader.readParameter(Collections.emptyMap(), false), is(nullValue()));
-        assertThat(secretReader.readParameter(Collections.emptyMap(), false), is(nullValue()));
+        assertThat(secretReader.readParameter(null, false), is(nullValue()));
+        assertThat(secretReader.readParameter(null, false), is(nullValue()));
 
         String secret = "P@ssword!";
-        assertThat(secretReader.readParameter(
-                        Collections.singletonMap(Config.ServiceInstanceParameters.SECRET, secret), true),
-                is(equalTo(secret)));
+        assertThat(secretReader.readParameter(secret, true), is(equalTo(secret)));
     }
 }

--- a/src/test/java/org/cloudfoundry/autosleep/util/TestUtils.java
+++ b/src/test/java/org/cloudfoundry/autosleep/util/TestUtils.java
@@ -47,7 +47,8 @@ public class TestUtils {
             fail("Expected exception " + wantedClass.getName() + " not thrown");
         } catch (Exception exc) {
             if (!wantedClass.isInstance(exc)) {
-                throw new RuntimeException("Expected " + wantedClass.getName() + " got " + wantedClass.getName(), exc);
+                throw new RuntimeException("Expected " + wantedClass.getName() + " got " + exc.getClass().getName(),
+                        exc);
             }
             T expectedClass = wantedClass.cast(exc);
             for (CheckerFunction<T> checker : checkers) {


### PR DESCRIPTION
Error thrown when : 
- unknown parameter on creation
- unknown or not modifiable parameter on update
- redesign AutosleepServiceInstanceServiceTest according to @gberche-orange showed last meeting....Hope I understood well... Please don't let him be misunderstood :musical_note: 
