### PR TITLE
fix #136 : Add reentrance if servic broker fails to delete

### DIFF
--- a/acceptance/1_service_broker_lifecycle.robot
+++ b/acceptance/1_service_broker_lifecycle.robot
@@ -9,6 +9,7 @@ Force Tags      Service broker
 0) Prepare
     [Documentation]     Clean service bindings and instance if exist
     Clean all service data
+    Check broker is not published
 
 1) create service broker
     [Documentation]     Create a service broker

--- a/acceptance/2_inactivity_detection.robot
+++ b/acceptance/2_inactivity_detection.robot
@@ -2,7 +2,7 @@
 Resource        Keywords.robot
 Documentation   Test if inactivity is detected
 Force Tags      Service broker
-Test Setup      Run Keywords  Clean all service data  Create service broker  Create service instance  Bind application
+Test Setup      Run Keywords  Clean all service data  Check broker is published  Create service instance  Bind application
 Test Teardown   Run Keywords  Clean all service data
 
 *** Test Cases ***

--- a/acceptance/3_application_unbind.robot
+++ b/acceptance/3_application_unbind.robot
@@ -15,7 +15,7 @@ ${INACTIVITY}  PT${INACTIVITY_IN_S}S
     [Documentation]     Check that app are still started ${DEFAULT_INACTIVITY} after their last http activity
 
 	Clean all service data
-	Create service broker
+	Check broker is published
 	Create service instance      ${INSTANCE_PARAMETERS}
 
 	Stop application

--- a/acceptance/4_application_autobind.robot
+++ b/acceptance/4_application_autobind.robot
@@ -13,7 +13,7 @@ ${INACTIVITY}  PT${INACTIVITY_IN_S}S
 1) Automatically bind application by service instance
     [Documentation]     Check that app is automatically bound by service instance
     Clean all service data
-    Create service broker
+    Check broker is published
 	${regex}					Catenate   SEPARATOR=      ^(?:(?!    ${TESTED_APP_NAME}   ).)*$
     ${parameters}				Create Dictionary	idle-duration=${INACTIVITY}	exclude-from-auto-enrollment=${regex}
     Create service instance      ${parameters}
@@ -23,7 +23,7 @@ ${INACTIVITY}  PT${INACTIVITY_IN_S}S
 2) Service does not bind ignored applications
     [Documentation]        Check that no application is bound by the service instance
     Clean all service data
-    Create service broker
+    Check broker is published
     ${parameters}				Create Dictionary	idle-duration=${INACTIVITY}	exclude-from-auto-enrollment=${EXCLUDE_ALL_APP_NAMES}
     Create service instance      ${parameters}
     ${halfPeriod}=      Evaluate  ${INACTIVITY_IN_S}/2

--- a/acceptance/5_no_optout_option.robot
+++ b/acceptance/5_no_optout_option.robot
@@ -2,7 +2,7 @@
 Resource        Keywords.robot
 Documentation   Test no-optout option, and secret parameter
 Force Tags      Service broker
-Test Setup      Run Keywords  Clean all service data  Create service broker
+Test Setup      Run Keywords  Clean all service data  Check broker is published
 Test Teardown   Run Keywords  Clean all service data
 
 *** Variables ***


### PR DESCRIPTION
From now we do not delete service broker and do not create it on each acceptance test.
Two approches:
- the test **needs** a service broker and will call `Check broker is published` at set up phase
- the test aims to test service broker declaration in marketplace and will call `Check broker is not published` at set up phase and then `Create service broker`/`Delete service broker` at the end
