### PR TITLE
Update application restarting

### DIFF
--- a/coverage.gradle
+++ b/coverage.gradle
@@ -12,11 +12,12 @@ jacocoTestReport {
     afterEvaluate {
         classDirectories = files(classDirectories.files.collect {
             fileTree(dir: it,
-                    exclude: ['org/cloudfoundry/autosleep/worker/remote/CloudFoundryApi*', //won't test cf-java-client
-                              'org.cloudfoundry/autosleep/worker/remote/model/**', //won't test pojo
-                              'org.cloudfoundry/autosleep/dao/model/**',  //won't test pojo
-                              'org.cloudfoundry/autosleep/config/ContextInitializer*', //won't test cloud context init
-                              'org/cloudfoundry/autosleep/Application*']) //
+                    exclude: ['org/cloudfoundry/autosleep/worker/remote/**', //won't test cf-java-client
+                              'org/cloudfoundry/autosleep/worker/scheduling/TimeManager.class', //won't java concurent
+                              'org/cloudfoundry/autosleep/worker/remote/model/**', //won't test pojo
+                              'org/cloudfoundry/autosleep/dao/model/**',  //won't test pojo
+                              'org/cloudfoundry/autosleep/config/ContextInitializer.class', //won't test cloud context init
+                              'org/cloudfoundry/autosleep/Application.class']) //
 
         })
     }

--- a/src/main/java/org/cloudfoundry/autosleep/worker/remote/CloudFoundryApi.java
+++ b/src/main/java/org/cloudfoundry/autosleep/worker/remote/CloudFoundryApi.java
@@ -168,7 +168,7 @@ public class CloudFoundryApi implements CloudFoundryApiService {
                 .build();
     }
 
-    private void changeApplicationState(String applicationUuid, String targetState) throws CloudFoundryException {
+    private boolean changeApplicationState(String applicationUuid, String targetState) throws CloudFoundryException {
         log.debug("changeApplicationState to {}", targetState);
         try {
             if (!targetState.equals(getApplicationState(applicationUuid))) {
@@ -179,8 +179,10 @@ public class CloudFoundryApi implements CloudFoundryApiService {
                                         .state(targetState)
                                         .build())
                         .get(Config.CF_API_TIMEOUT);
+                return true;
             } else {
                 log.warn("application {} already in state {}, nothing to do", applicationUuid, targetState);
+                return false;
             }
         } catch (RuntimeException r) {
             throw new CloudFoundryException(r);
@@ -262,9 +264,9 @@ public class CloudFoundryApi implements CloudFoundryApiService {
                                     .guid(appUid)
                                     .name(app.getName())
                                     .build())
-                            .state(app.getState())
                             .lastEvent(buildAppEvent(lastEventReference.get()))
                             .lastLog(buildAppLog(lastLogReference.get()))
+                            .state(app.getState())
                             .build();
                 }
         } catch (InterruptedException e) {
@@ -358,15 +360,15 @@ public class CloudFoundryApi implements CloudFoundryApiService {
     }
 
     @Override
-    public void startApplication(String applicationUuid) throws CloudFoundryException {
+    public boolean startApplication(String applicationUuid) throws CloudFoundryException {
         log.debug("startApplication");
-        changeApplicationState(applicationUuid, CloudFoundryAppState.STARTED);
+        return changeApplicationState(applicationUuid, CloudFoundryAppState.STARTED);
     }
 
     @Override
-    public void stopApplication(String applicationUuid) throws CloudFoundryException {
+    public boolean stopApplication(String applicationUuid) throws CloudFoundryException {
         log.debug("stopApplication");
-        changeApplicationState(applicationUuid, CloudFoundryAppState.STOPPED);
+        return changeApplicationState(applicationUuid, CloudFoundryAppState.STOPPED);
     }
 
     @Override

--- a/src/main/java/org/cloudfoundry/autosleep/worker/remote/CloudFoundryApiService.java
+++ b/src/main/java/org/cloudfoundry/autosleep/worker/remote/CloudFoundryApiService.java
@@ -44,9 +44,9 @@ public interface CloudFoundryApiService {
 
     List<String/**ids**/> listRouteApplications(String routeUuid) throws CloudFoundryException;
 
-    void startApplication(String applicationUuid) throws CloudFoundryException;
+    boolean startApplication(String applicationUuid) throws CloudFoundryException;
 
-    void stopApplication(String applicationUuid) throws CloudFoundryException;
+    boolean stopApplication(String applicationUuid) throws CloudFoundryException;
 
     void unbind(String bindingId) throws CloudFoundryException;
 

--- a/src/main/java/org/cloudfoundry/autosleep/worker/scheduling/Clock.java
+++ b/src/main/java/org/cloudfoundry/autosleep/worker/scheduling/Clock.java
@@ -41,7 +41,7 @@ import java.util.concurrent.TimeUnit;
 public class Clock {
 
     @Autowired
-    private ScheduledExecutorService scheduler;
+    private TimeManager timeManager;
 
     private final Map<String/*taskId*/, ScheduledFuture<?>> tasks = new HashMap<>();
 
@@ -70,7 +70,7 @@ public class Clock {
      */
     public void scheduleTask(String id, Duration duration, Runnable action) {
         log.debug("scheduleTask - task {}", id);
-        ScheduledFuture<?> handle = scheduler.schedule(action, duration.toMillis(), TimeUnit.MILLISECONDS);
+        ScheduledFuture<?> handle = timeManager.schedule(action, duration);
         tasks.put(id, handle);
     }
 

--- a/src/main/java/org/cloudfoundry/autosleep/worker/scheduling/TimeManager.java
+++ b/src/main/java/org/cloudfoundry/autosleep/worker/scheduling/TimeManager.java
@@ -20,18 +20,26 @@
 package org.cloudfoundry.autosleep.worker.scheduling;
 
 import org.cloudfoundry.autosleep.config.Config;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Service;
 
+import java.time.Duration;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 
-@Configuration
-public class SchedulerConfig {
+@Service
+public class TimeManager {
 
-    @Bean
-    public ScheduledExecutorService getScheduler() {
-        return Executors.newScheduledThreadPool(Config.NB_THREAD_FOR_TASK);
+    private ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(Config.NB_THREAD_FOR_TASK);
+
+    public ScheduledFuture<?> schedule(Runnable command,
+                                       Duration duration) {
+        return scheduler.schedule(command, duration.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    public void sleep(Duration duration) throws InterruptedException {
+        Thread.sleep(duration.toMillis());
     }
 
 }

--- a/src/test/java/org/cloudfoundry/autosleep/worker/ClockTest.java
+++ b/src/test/java/org/cloudfoundry/autosleep/worker/ClockTest.java
@@ -21,6 +21,7 @@ package org.cloudfoundry.autosleep.worker;
 
 import lombok.extern.slf4j.Slf4j;
 import org.cloudfoundry.autosleep.worker.scheduling.Clock;
+import org.cloudfoundry.autosleep.worker.scheduling.TimeManager;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -56,7 +57,7 @@ public class ClockTest {
     private Runnable runnable;
 
     @Mock
-    private ScheduledExecutorService scheduler;
+    private TimeManager timeManager;
 
     @Test
     public void test_list_tasks_ids() throws Exception {
@@ -88,6 +89,6 @@ public class ClockTest {
         //When we schedule a task
         clock.scheduleTask(TEST_ID, PERIOD, runnable);
         //It does not run immediately
-        verify(scheduler, times(1)).schedule(eq(runnable), eq(PERIOD.toMillis()), eq(TimeUnit.MILLISECONDS));
+        verify(timeManager, times(1)).schedule(eq(runnable), eq(PERIOD));
     }
 }


### PR DESCRIPTION
- Externalize all "time" operation in a `@Service` (allows to fasten unit tests)
- start/stop application return a `boolean` telling if a request to start/stop was done (meaning application was already started/stopped)
