### PR TITLE
Refined specs to fix #169

### DIFF
--- a/acceptance/5_no_optout_option.robot
+++ b/acceptance/5_no_optout_option.robot
@@ -11,13 +11,13 @@ ${DEFAULT_INACTIVITY_IN_S}  6
 ${DEFAULT_INACTIVITY}  PT${DEFAULT_INACTIVITY_IN_S}S
 
 *** Test Cases ***
-1) No auto-enrollment without secret
+1) No forced auto-enrollment without secret
     [Documentation]              Check that we can not create a service with no-optout option without providing a secret
     ${parameters}                Create Dictionary	idle-duration=${DEFAULT_INACTIVITY}	exclude-from-auto-enrollment=${EXCLUDE_ALL_APP_NAMES}   auto-enrollment=forced   autosleep-despite-route-services-error=true
     Run Keyword And Expect Error    InvalidStatusCode: 502*Service broker error: \'auto-enrollment\': *     Create service instance  ${parameters}
 
 
-2) Auto-enrollment can unbind, but will be rebound
+2) Forced auto-enrollment can unbind, but will be rebound
     [Documentation]     Check that we can not unbind an app from a service with auto-enrollment option set to true
     # create service instance with noptout
     ${parameters}                Create Dictionary	idle-duration=${DEFAULT_INACTIVITY}	secret=${DEFAULT_SECRET}   auto-enrollment=forced
@@ -33,18 +33,35 @@ ${DEFAULT_INACTIVITY}  PT${DEFAULT_INACTIVITY_IN_S}S
 
     Wait Until Keyword Succeeds     ${longPeriod}s  3s  Should be bound
 
-3) Auto-enrollment service can not change without secret
-    [Documentation]        Check that the auto-enrollment option of a service can not be updated without providing a secret
+3) Forced auto-enrollment can unbind, but will be rebound
+    [Documentation]     Check that we can not unbind an app from a service with auto-enrollment option set to true
+    # create service instance with noptout
+    ${parameters}                Create Dictionary	idle-duration=${DEFAULT_INACTIVITY}	secret=${DEFAULT_SECRET}   auto-enrollment=forced
+    Create service instance      ${parameters}
+
+    Bind application
+
+    ## unbind service instance
+    Unbind application
+
+
+    ${longPeriod}=      Evaluate  ${DEFAULT_INACTIVITY_IN_S}*3
+
+    Wait Until Keyword Succeeds     ${longPeriod}s  3s  Should be bound
+
+4) Forced auto-enrollment mode can not delete autosleep service instance
+    [Documentation]        Check that during forced auto-enrollment mode, a service instance can't be deleted to escape from autoenrolling apps within the space
     # create service instance  with noptout
     ${parameters}                Create Dictionary	idle-duration=${DEFAULT_INACTIVITY}	exclude-from-auto-enrollment=${EXCLUDE_ALL_APP_NAMES}   auto-enrollment=forced  secret=${DEFAULT_SECRET}
     Create service instance       ${parameters}
 
-    # update service -> refuse
-    ${parameters}                Create Dictionary	auto-enrollment=standard
-    Run Keyword And Expect Error    InvalidStatusCode: 502*Service broker error: \'auto-enrollment\': *    Update service instance   ${parameters}
+    # delete service -> refuse
+    Delete service instance
+    ${maxToWait}=      Evaluate  2*${DEFAULT_INACTIVITY_IN_S}
+    Run Keyword And Expect Error    InvalidStatusCode: 502*Service broker error: \this autosleep service instance can't be delete during forced enrollment mode. Switch back to normal enrollment mode to enable deletes
 
 
-4) Auto-enrollment service can not change with wrong secret
+5) Auto-enrollment mode can not change with wrong secret
     [Documentation]        Check that the auto-enrollment option of a service can not be updated without providing the right secret
     # create service instance with noptout
     ${parameters}                Create Dictionary	idle-duration=${DEFAULT_INACTIVITY}	exclude-from-auto-enrollment=${EXCLUDE_ALL_APP_NAMES}   auto-enrollment=forced  secret=${DEFAULT_SECRET}
@@ -55,7 +72,7 @@ ${DEFAULT_INACTIVITY}  PT${DEFAULT_INACTIVITY_IN_S}S
     Run Keyword And Expect Error    InvalidStatusCode: 502*Service broker error: \'secret\': *    Update service instance   ${parameters}
 
 
-5) Auto-enrollment service can change with right secret
+6) Auto-enrollment mode can change with right secret
     [Documentation]        Check that the auto-enrollment option can be changed if the right secret is provided
     # create service instance with noptout
     ${parameters}                Create Dictionary	idle-duration=${DEFAULT_INACTIVITY}	exclude-from-auto-enrollment=${EXCLUDE_ALL_APP_NAMES}   auto-enrollment=forced  secret=${DEFAULT_SECRET}
@@ -72,7 +89,7 @@ ${DEFAULT_INACTIVITY}  PT${DEFAULT_INACTIVITY_IN_S}S
     # check unbind -> accept
     Unbind application
 
-6) Auto-enrollment service can change with admin secret
+7) Auto-enrollment service can change with admin secret
     [Documentation]        Check that the auto-enrollment option can be changed if the admin secret is provided
     # create service instance with noptout
     ${parameters}                Create Dictionary	idle-duration=${DEFAULT_INACTIVITY}	exclude-from-auto-enrollment=${EXCLUDE_ALL_APP_NAMES}   auto-enrollment=forced  secret=${DEFAULT_SECRET}


### PR DESCRIPTION
Indeed during forced mode, the autosleep service instance should refuse to delete, otherwise space members can escape from forced enrollement in the space.
