### PR TITLE
Fix log too verbose

### DIFF
--- a/common/src/main/resources/logback.xml
+++ b/common/src/main/resources/logback.xml
@@ -27,7 +27,7 @@
         </encoder>
     </appender>
     <logger name="org.cloudfoundry.autosleep">
-        <if condition='property("autosleep.debug").contains("true")'>
+        <if condition='property("autosleep.debug").contains("autosleep")'>
             <then>
                 <level value="DEBUG"/>
             </then>
@@ -37,15 +37,18 @@
         </if>
     </logger>
     <logger name="org.springframework">
-        <level value="WARN"/>
+        <if condition='property("autosleep.debug").contains("spring")'>
+            <then>
+                <level value="DEBUG"/>
+            </then>
+            <else>
+                <level value="WARN"/>
+            </else>
+        </if>
     </logger>
-    <logger name="org.apache.http.wire">
-        <level value="WARN"/>
-    </logger>
-
     <root>
         <appender-ref ref="stdout"/>
         <!--<level value="OFF" />-->
-        <level value="INFO"/>
+        <level value="WARN"/>
     </root>
 </configuration>

--- a/doc/publish.md
+++ b/doc/publish.md
@@ -33,6 +33,7 @@ Autosleep service needs properties to work . The properties that are used are:
 - __cf.security.password.encodingSecret__: the secret used to hash password (optional). If none provided, it will use ```""```.
 - __cf.service.broker.id__: the service broker id that is used as a "service offering name" and will appear in the marketplace. If none provided, it will use ```"autosleep"```. Must be unique in the CF instance across all brokers.
 - __cf.service.plan.id__: the service plan id. If none provided, it will use ```"default"```. Must be unique in the CF instance across all brokers.
+- __autosleep.debug__: a list too enable `DEBUG` logs. So far, the available keys are `autosleep` to turn applicative logs in `DEBUG`, and `spring`for the spring part.
 
 There are two ways of providing these properties to autosleep:
 

--- a/doc/publish.md
+++ b/doc/publish.md
@@ -33,7 +33,7 @@ Autosleep service needs properties to work . The properties that are used are:
 - __cf.security.password.encodingSecret__: the secret used to hash password (optional). If none provided, it will use ```""```.
 - __cf.service.broker.id__: the service broker id that is used as a "service offering name" and will appear in the marketplace. If none provided, it will use ```"autosleep"```. Must be unique in the CF instance across all brokers.
 - __cf.service.plan.id__: the service plan id. If none provided, it will use ```"default"```. Must be unique in the CF instance across all brokers.
-- __autosleep.debug__: a list too enable `DEBUG` logs. So far, the available keys are `autosleep` to turn applicative logs in `DEBUG`, and `spring`for the spring part.
+- __autosleep.debug__: a list to enable `DEBUG` logs. So far, the available keys are `autosleep` to turn applicative logs in `DEBUG`, and `spring` for the spring part.
 
 There are two ways of providing these properties to autosleep:
 

--- a/manifest.tmpl.yml
+++ b/manifest.tmpl.yml
@@ -12,7 +12,7 @@ env:
   cf.security.password.encodingSecret: <password_encoding_secret>
   cf.service.broker.id: <service_broker_id>
   cf.service.plan.id: <service_plan_id>
-  autosleep.debug: <true/false>
+  autosleep.debug: <autosleep, spring, ....>
   JAVA_OPTS: >
     -Dlogging.level.org.springframework.web.filter.CommonsRequestLoggingFilter=ERROR
 


### PR DESCRIPTION
All logs will be in warning (post application loading) except application ones that are in INFO by default
The property autosleep.debug may contain a string. If it contains autosleep, all applicative logs will be in  DEBUG. If it contains spring, all spring log will be in debug
