### PR TITLE
Add broker name and plan name in configuration

### DIFF
--- a/common/src/main/java/org/cloudfoundry/autosleep/config/Config.java
+++ b/common/src/main/java/org/cloudfoundry/autosleep/config/Config.java
@@ -55,7 +55,11 @@ public interface Config {
 
         String CF_SERVICE_BROKER_ID = "cf.service.broker.id";
 
+        String CF_SERVICE_BROKER_NAME = "cf.service.broker.name";
+
         String CF_SERVICE_PLAN_ID = "cf.service.plan.id";
+
+        String CF_SERVICE_PLAN_NAME = "cf.service.plan.name";
 
         String CF_SKIP_SSL_VALIDATION = "cf.client.skip.ssl.validation";
 
@@ -85,7 +89,11 @@ public interface Config {
 
         String DEFAULT_SERVICE_BROKER_ID = "autosleep";
 
+        String DEFAULT_SERVICE_BROKER_NAME = "autosleep";
+
         String DEFAULT_SERVICE_PLAN_ID = "default";
+
+        String DEFAULT_SERVICE_PLAN_NAME = "default";
     }
 
     interface ServiceInstanceParameters {
@@ -100,17 +108,17 @@ public interface Config {
 
         String IDLE_DURATION = "idle-duration";
 
-        String SECRET = "secret";
-
         String IGNORE_ROUTE_SERVICE_ERROR = "autosleep-despite-route-services-error";
+
+        String SECRET = "secret";
 
     }
 
     Duration CF_API_TIMEOUT = Duration.ofSeconds(8);
 
-    Duration DEFAULT_INACTIVITY_PERIOD = Duration.ofDays(1);
-
     Boolean DEFAULT_IGNORE_SERVICE_ERROR = Boolean.FALSE;
+
+    Duration DEFAULT_INACTIVITY_PERIOD = Duration.ofDays(1);
 
     Duration DELAY_BEFORE_FIRST_SERVICE_CHECK = Duration.ofSeconds(10);
 

--- a/doc/publish.md
+++ b/doc/publish.md
@@ -20,26 +20,38 @@ Prerequisites:
 * (optional) a dedicated space to deploy autosleep and autowakeup apps on which CF users don't have acces.s
 
 
-Autosleep service needs properties to work . The properties that are used are:
+Autosleep service needs properties to work . 
+There are two ways of providing these properties to autosleep:
 
+1. In _manifest.yml_: by giving these informations in the _manifest.yml_, in the _JAVA_OPTS_ section.
+2. By providing them directly in  the _env_ section of the _manifest.yml_. Note that [acccording to the documentation](http://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#env-block), you will be able to update them afer the first deployment with the command `cf  set-env <application name> <property name>  <property value>`. Keep in mind that dot characters are forbidden by cloudfoundry cli and must be replaced by underscores. For example, you may provide the username like this `cf  set-env my-autosleep-service cf_client_username  bobby`.
+
+The properties that are used are:
+
+##### _Basic authentication_
 - __security.user.name__: the basic auth username that protects access to the service broker.
 - __security.user.password__: the basic auth password that protects access to the service broker.
+##### _Cloudfoundry client_
 - __cf.client.target.host__: the expected **hostname** of cloudfoundry CC api endpoint (port is always 443)
 - __cf.client.skip.ssl.validation__: set this property to _true_ if the current cloudfoundry CC API endpoint uses self-signed certificates.
 - __cf.client.username__: the username of the pre-requisite CC API user that will be used in by the autosleep service to list/stop/start apps.
 - __cf.client.password__: the password of the pre-requisite CC API user that will be used in by the autosleep service to list/stop/start apps.
 - __cf.client.clientId__: the (optional) client id of the application used to perform CC API calls. If none provided, it will used ```"cf"```.
 - __cf.client.clientSecret__: the optional client secret of the application (optional) used to perform CC API calls. If none provided, it will used ```""```.
+#### _Service broker_
+For this section, we advice you to take a look at the [documentation](http://docs.cloudfoundry.org/services/api.html#catalog-mgmt)
+
+- __cf.service.broker.id__: the service broker id that is used as a "service unique id". If none provided, it will use ```"autosleep"```. Must be unique in the CF instance across all brokers.
+- __cf.service.broker.name__: the service broker name that is used as a "service offering name" and will appear in the marketplace. If none provided, it will use ```"autosleep"```.
+- __cf.service.plan.id__: the service plan id. If none provided, it will use ```"default"```. Must be unique in the CF plans across all brokers.
+- __cf.service.plan.name__: the service plan name that is used and will appear in the marketplace. If none provided, it will use ```"default"```.
+
+#### _Other properties_
 - __cf.security.password.encodingSecret__: the secret used to hash password (optional). If none provided, it will use ```""```.
-- __cf.service.broker.id__: the service broker id that is used as a "service offering name" and will appear in the marketplace. If none provided, it will use ```"autosleep"```. Must be unique in the CF instance across all brokers.
-- __cf.service.plan.id__: the service plan id. If none provided, it will use ```"default"```. Must be unique in the CF instance across all brokers.
+
 - __autosleep.debug__: a list to enable `DEBUG` logs. So far, the available keys are `autosleep` to turn applicative logs in `DEBUG`, and `spring` for the spring part.
 - __autowakeup.skip.ssl.validation__: set this property to _true_ if the applications that need to be restarted by _autowakeup_ use self-signed certificates.
 
-There are two ways of providing these properties to autosleep:
-
-1. In _manifest.yml_: by giving these informations in the _manifest.yml_, in the _JAVA_OPTS_ section.
-2. By providing them directly in  the _env_ section of the _manifest.yml_. Note that [acccording to the documentation](http://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#env-block), you will be able to update them afer the first deployment with the command `cf  set-env <application name> <property name>  <property value>`. Keep in mind that dot characters are forbidden by cloudfoundry cli and must be replaced by underscores. For example, you may provide the username like this `cf  set-env my-autosleep-service cf_client_username  bobby`
 
 ### Deploy autosleep app
 

--- a/manifest.tmpl.yml
+++ b/manifest.tmpl.yml
@@ -11,7 +11,9 @@ env:
   cf.client.clientSecret: <client_secret>
   cf.security.password.encodingSecret: <password_encoding_secret>
   cf.service.broker.id: <service_broker_id>
+  cf.service.broker.name: <service_broker_name>
   cf.service.plan.id: <service_plan_id>
+  cf.service.plan.name: <service_plan_name>
   autosleep.debug: <autosleep, spring, ....>
   JAVA_OPTS: >
     -Dlogging.level.org.springframework.web.filter.CommonsRequestLoggingFilter=ERROR

--- a/spring-apps/autosleep-core/src/main/java/org/cloudfoundry/autosleep/ui/servicebroker/configuration/AutosleepCatalogBuilder.java
+++ b/spring-apps/autosleep-core/src/main/java/org/cloudfoundry/autosleep/ui/servicebroker/configuration/AutosleepCatalogBuilder.java
@@ -20,10 +20,11 @@
 package org.cloudfoundry.autosleep.ui.servicebroker.configuration;
 
 import org.cloudfoundry.autosleep.config.Config;
+import org.cloudfoundry.autosleep.config.Config.EnvKey;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.servicebroker.model.Catalog;
 import org.springframework.cloud.servicebroker.model.Plan;
 import org.springframework.cloud.servicebroker.model.ServiceDefinition;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.servicebroker.model.ServiceDefinitionRequires;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -42,21 +43,28 @@ public class AutosleepCatalogBuilder {
 
     @Bean
     public Catalog buildCatalog() {
+
         String serviceBrokerId = environment.getProperty(Config.EnvKey.CF_SERVICE_BROKER_ID,
                 Config.ServiceCatalog.DEFAULT_SERVICE_BROKER_ID);
+
+        String serviceBrokerName = environment.getProperty(EnvKey.CF_SERVICE_BROKER_NAME,
+                Config.ServiceCatalog.DEFAULT_SERVICE_BROKER_NAME);
 
         String servicePlanId = environment.getProperty(Config.EnvKey.CF_SERVICE_PLAN_ID,
                 Config.ServiceCatalog.DEFAULT_SERVICE_PLAN_ID);
 
+        String servicePlanName = environment.getProperty(EnvKey.CF_SERVICE_PLAN_NAME,
+                Config.ServiceCatalog.DEFAULT_SERVICE_PLAN_NAME);
+
         return new Catalog(Collections.singletonList(new ServiceDefinition(
                 serviceBrokerId,
-                serviceBrokerId,
+                serviceBrokerName,
                 "Automatically stops inactive apps",
                 true,
                 false,
                 Collections.singletonList(
                         new Plan(servicePlanId,
-                                "default",
+                                servicePlanName,
                                 "Autosleep default plan",
                                 null,
                                 true)),


### PR DESCRIPTION
Currently broker name and plan name were set valued as broker id and plan id.This change brings the possibility to configure them separately

See #181
