### PR TITLE
Notify CF Slack channel of travis build status

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,4 @@ after_success:
   - ./gradlew jacocoRootReport coveralls
 notifications:
   slack: autosleep:eY0VgmPawVzYa7tWKhmnBdES
+  slack: cloudfoundry:CxDiILV5x3kUYhJFfM2dCKxt


### PR DESCRIPTION
Adding integration to publish a status on https://cloudfoundry.slack.com/messages/autosleep/ following migration to https://github.com/cloudfoundry-community/autosleep
