### PR TITLE
Adding sample acceptance tests report

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,2396 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<meta http-equiv="Pragma" content="no-cache">
+<meta http-equiv="Expires" content="-1">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta content="Robot Framework 2.9.2 (Python 2.7.10 on linux2)" name="Generator">
+<link rel="icon" type="image/x-icon" href="data:image/x-icon;base64,AAABAAEAEBAQAAEABAAoAQAAFgAAACgAAAAQAAAAIAAAAAEABAAAAAAAAAIAAAAAAAAAAAAAEAAAAAAAAAAAAAAAJEBoACtnfgA5cYYAERsiAEx2lAAbKkQAcazBACZCVwAcM1cAK0ucAAMDBQAnQncASG+FABkoVQAyWmgA6f8SgvH/Ij99+GLyIinyJfn/Yi//KSLzUy9iZogpIld3/4JVVTkid7vyUjNVNVJEAGOZ6Z7pXwAABpmZkRiLAAAGiJZpmGAAAEEt3SXdxAAATC7o/u3EAAC8MRZpjasAAAY1VVVTYAAABKqqqqpAAAAADKqq4AAAAAAAv4sAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMADAADgAwAA4AcAAOAHAADgBwAAwAcAAOAHAADgDwAA8A8AAPg/AAD+fwAA">
+<style media="all" type="text/css">
+/* Generic and misc styles */
+body {
+    font-family: Helvetica, sans-serif;
+    font-size: 0.8em;
+    color: black;
+    padding: 6px;
+    background: white;
+}
+table {
+    table-layout: fixed;
+    word-wrap: break-word;
+    empty-cells: show;
+    font-size: 1em;
+}
+th, td {
+    vertical-align: top;
+}
+br {
+    mso-data-placement: same-cell; /* maintain line breaks in Excel */
+}
+a, a:link, a:visited {
+    text-decoration: none;
+    color: #15c;
+}
+a > img {
+    border: 1px solid #15c !important;
+}
+a:hover, a:active {
+    text-decoration: underline;
+    color: #61c;
+}
+.parent-name {
+    font-size: 0.7em;
+    letter-spacing: -0.07em;
+}
+.message {
+    white-space: pre-wrap;
+}
+/* Headers */
+#header {
+    width: 65em;
+    height: 3em;
+    margin: 6px 0;
+}
+h1 {
+    float: left;
+    margin: 0 0 0.5em 0;
+    width: 75%;
+}
+h2 {
+    clear: left;
+}
+#generated {
+    float: right;
+    text-align: right;
+    font-size: 0.9em;
+    white-space: nowrap;
+}
+/* Documentation headers */
+.doc > h2 {
+    font-size: 1.2em;
+}
+.doc > h3 {
+    font-size: 1.1em;
+}
+.doc > h4 {
+    font-size: 1.0em;
+}
+/* Status text colors -- !important allows using them in links */
+.fail {
+    color: #f33 !important;
+    font-weight: bold;
+}
+.pass {
+    color: #393 !important;
+}
+.label {
+    padding: 2px 5px;
+    font-size: 0.75em;
+    letter-spacing: 1px;
+    white-space: nowrap;
+    color: black;
+    background-color: #ddd;
+    border-radius: 3px;
+}
+.label.debug, .label.trace, .label.error, .label.keyword {
+    letter-spacing: 0;
+}
+.label.error, .label.fail, .label.pass, .label.warn {
+    color: #fff !important;
+    font-weight: bold;
+}
+.label.error, .label.fail {
+    background-color: #d9534f;
+}
+.label.pass {
+    background-color: #5cb85c;
+}
+.label.warn {
+    background-color: #ec971f;
+}
+/* Top right header */
+#top-right-header {
+    position: fixed;
+    top: 0;
+    right: 0;
+    z-index: 1000;
+    width: 12em;
+    text-align: center;
+}
+#report-or-log-link a {
+    display: block;
+    background: black;
+    color: white;
+    text-decoration: none;
+    font-weight: bold;
+    letter-spacing: 0.1em;
+    padding: 0.3em 0;
+    border-bottom-left-radius: 4px;
+}
+#report-or-log-link a:hover {
+    color: #ddd;
+}
+#log-level-selector {
+    padding: 0.3em 0;
+    font-size: 0.9em;
+    border-bottom-left-radius: 4px;
+    background: #ddd;
+}
+/* Statistics table */
+.statistics {
+    width: 65em;
+    border-collapse: collapse;
+    empty-cells: show;
+    margin-bottom: 1em;
+}
+.statistics tr:hover {
+    background: #f4f4f4;
+    cursor: pointer;
+}
+.statistics th, .statistics td {
+    border: 1px solid #ccc;
+    padding: 0.1em 0.3em;
+}
+.statistics th {
+    background-color: #ddd;
+    padding: 0.2em 0.3em;
+}
+.statistics td {
+    vertical-align: middle;
+}
+.stats-col-stat {
+    width: 4.5em;
+    text-align: center;
+}
+.stats-col-elapsed {
+    width: 5.5em;
+    text-align: center;
+}
+.stats-col-graph {
+    width: 9em;
+}
+th.stats-col-graph:hover {
+    cursor: default;
+}
+.stat-name {
+    float: left;
+}
+.stat-name a, .stat-name span {
+    font-weight: bold;
+}
+.tag-links {
+    font-size: 0.9em;
+    float: right;
+    margin-top: 0.05em;
+}
+.tag-links span {
+    margin-left: 0.2em;
+}
+/* Statistics graph */
+.graph, .empty-graph {
+    border: 1px solid #ccc;
+    width: auto;
+    height: 7px;
+    padding: 0;
+    background: #f33;
+}
+.empty-graph {
+    background: #eee;
+}
+.pass-bar, .fail-bar {
+    float: left;
+    height: 100%;
+}
+.pass-bar {
+    background: #1d4;
+}
+/* Tablesorter - adapted from provided Blue Skin */
+.tablesorter-header {
+    background-image: url(data:image/gif;base64,R0lGODlhCwAJAIAAAH9/fwAAACH5BAEAAAEALAAAAAALAAkAAAIRjAOnBr3cnIr0WUjTrC9e9BQAOw==);
+    background-repeat: no-repeat;
+    background-position: center right;
+    cursor: pointer;
+}
+.tablesorter-header:hover {
+    background-color: #ccc;
+}
+.tablesorter-headerAsc {
+    background-image: url(data:image/gif;base64,R0lGODlhCwAJAKEAAAAAAH9/fwAAAAAAACH5BAEAAAIALAAAAAALAAkAAAIUlBWnFr3cnIr0WQOyBmvzp13CpxQAOw==);
+    background-color: #ccc !important;
+}
+.tablesorter-headerDesc {
+    background-image: url(data:image/gif;base64,R0lGODlhCwAJAKEAAAAAAH9/fwAAAAAAACH5BAEAAAIALAAAAAALAAkAAAIUlAWnBr3cnIr0WROyDmvzp13CpxQAOw==);
+    background-color: #ccc !important;
+}
+.sorter-false {
+    background-image: none;
+    cursor: default;
+}
+.sorter-false:hover {
+    background-color: #ddd;
+}
+</style>
+<style media="all" type="text/css">
+/* Generic table styles */
+table {
+    margin: 0 1px;
+    background: white;
+}
+tr {
+    background: white;
+}
+th {
+    background: #ddd;
+    color: black;
+}
+/* Summary and total/tag/suite details */
+.details {
+    border: 1px solid #ccc;
+    border-collapse: collapse;
+    clear: both;
+    width: 65em;
+    margin-bottom: 1em;
+}
+.details th {
+    background: white;
+    width: 10em;
+    white-space: nowrap;
+    text-align: left;
+    vertical-align: top;
+    padding: 0.2em 0.4em;
+}
+.details td {
+    vertical-align: top;
+    padding: 0.2em 0.4em;
+}
+.selector th, .selector td {
+    padding-top: 0.5em;
+    padding-bottom: 0.5em;
+    white-space: normal;
+}
+.first-selector th, .first-selector td{
+    padding-bottom: 0.2em;
+}
+.middle-selector th, .middle-selector td {
+    padding-top: 0.2em;
+    padding-bottom: 0.2em;
+}
+.last-selector th, .last-selector td{
+    padding-top: 0.2em;
+}
+#print-selector {
+    display: none;
+}
+/* Search */
+#search-suite, #search-test, #search-include, #search-exclude {
+    width: 25em;
+}
+#search a:hover {
+    text-decoration: none;
+}
+#search-help div {
+    margin: 0.5em 0.5em 0.7em 0;
+    padding: 0.7em;
+    background: #eee;
+    border: 1px solid #ccc;
+    border-radius: 3px;
+}
+#search-help h3, #search-help p {
+    margin: 0 0 0.7em 0;
+}
+.search-help-examples {
+    table-layout: auto;
+    width: 100%;
+}
+.search-help-examples, .search-help-examples tr,
+.search-help-examples th, .search-help-examples td {
+    background: transparent;
+    margin: 0;
+}
+.search-help-examples th, .search-help-examples td {
+    padding: 0.2em 0.7em 0.2em 0;
+}
+.help-item {
+    width: 10%;
+}
+.help-explanation {
+    width: 65%;
+}
+.help-examples {
+    width: 25%;
+}
+/* Tabs - adapted from http://www.htmldog.com/articles/tabs */
+#detail-tabs {
+    list-style: none;
+    padding: 0;
+    margin: 0 1em;
+}
+.detail-tab {
+    float: left;
+    background: #ddd;
+    border: 1px solid #ccc;
+    border-bottom-width: 0;
+    margin: 0 0.5em 0 0;
+    padding-top: 0.1em;
+    border-radius: 3px 3px 0 0;
+}
+.detail-tab:hover {
+    background: #ccc;
+}
+.detail-tab a {
+    color: black;
+    text-decoration: none;
+    font-weight: bold;
+    padding: 0 1em;
+}
+.detail-tab-selected {
+    position: relative;
+    top: 1px;
+    background: white;
+}
+.detail-tab-selected:hover {
+    background: white;
+}
+/* Test details table */
+#test-details {
+    width: 100%;
+    border-spacing: 1px;
+    background-color: #ccc;
+}
+#test-details > tbody > tr:hover {
+    background: #f4f4f4;
+    cursor: pointer;
+}
+#test-details th, #test-details td {
+    padding: 0.2em;
+}
+.details-limited {
+    max-height: 20em;
+    overflow: auto;
+}
+.details-col-header {
+    padding-right: 1em;
+}
+.details-col-toggle {
+    float: left;
+    color: #6c6c6c; /* same as in sort icon */
+    cursor: pointer;
+}
+.details-col-toggle:hover {
+    color: black;
+}
+.details-col-name {
+    min-width: 20em;
+    font-weight: bold;
+}
+.details-col-doc {
+    min-width: 10em;
+}
+.details-col-tags {
+    min-width: 10em;
+}
+.details-col-crit {
+    width: 3.5em;
+    text-align: center;
+}
+.details-col-status {
+    width: 4.5em;
+    text-align: center;
+}
+.details-col-msg {
+    min-width: 20em;
+}
+.details-col-elapsed {
+    width: 7em;
+    text-align: center;
+}
+.details-col-times {
+    width: 11em;
+    white-space: nowrap;
+    text-align: center;
+}
+.hidden .details-col-header, td.hidden > div {
+    display: none;
+}
+.hidden {
+    width: 13px;
+    min-width: 0;
+    background-image: none;
+}
+th.hidden:hover {
+    background-color: #ccc;
+}
+</style>
+<style media="print" type="text/css">
+body {
+    background: white !important;
+    padding: 0;
+    font-size: 8pt;
+}
+a:link, a:visited {
+    color: black;
+}
+#header {
+    width: auto;
+}
+.details, .statistics {
+    width: 100%;
+}
+#generated-ago, #top-right-header, #normal-selector, #search-buttons,
+.folding-button, .expand, .hidden, .details-col-toggle {
+    display: none;
+}
+.element-header-text, .children {
+    margin: 0;
+}
+#test-details {
+    border-collapse: collapse;
+    table-layout: auto;
+}
+#test-details th, #test-details td {
+    border: 1px solid black;
+}
+.details-col-header {
+    padding: 0;
+}
+#print-selector {
+    display: table-cell;
+}
+.tablesorter-header {
+    background-image: none;
+    background: #ddd !important;
+}
+</style>
+<style media="all" type="text/css">
+#javascript-disabled {
+    width: 600px;
+    margin: 100px auto 0 auto;
+    padding: 20px;
+    color: black;
+    border: 1px solid #ccc;
+    background: #eee;
+}
+#javascript-disabled h1 {
+    width: 100%;
+    float: none;
+}
+#javascript-disabled ul {
+    font-size: 1.2em;
+}
+#javascript-disabled li {
+    margin: 0.5em 0;
+}
+#javascript-disabled b {
+    font-style: italic;
+}
+</style>
+<style media="all" type="text/css">
+.doc > * {
+    margin: 0.7em 1em 0.1em 1em;
+    padding: 0;
+}
+.doc > p, .doc > h1, .doc > h2, .doc > h3, .doc > h4 {
+    margin: 0.7em 0 0.1em 0;
+}
+.doc > *:first-child {
+    margin-top: 0.1em;
+}
+.doc table {
+    border: 1px solid #ccc;
+    background: transparent;
+    border-collapse: collapse;
+    empty-cells: show;
+    font-size: 0.9em;
+}
+.doc table th, .doc table td {
+    border: 1px solid #ccc;
+    background: transparent;
+    padding: 0.1em 0.3em;
+    height: 1.2em;
+}
+.doc table th {
+    text-align: center;
+    letter-spacing: 0.1em;
+}
+.doc pre {
+    font-size: 1.1em;
+    letter-spacing: 0.05em;
+    background: #eee;
+}
+.doc code {
+    padding: 0 0.2em;
+    letter-spacing: 0.05em;
+    background: #eee;
+}
+.doc li {
+    list-style-position: inside;
+    list-style-type: square;
+}
+.doc img {
+    border: 1px solid #ccc;
+}
+.doc hr {
+    background: #ccc;
+    height: 1px;
+    border: 0;
+}
+</style>
+<script type="text/javascript">
+/*! jQuery v1.8.3 jquery.com | jquery.org/license */
+(function(e,t){function _(e){var t=M[e]={};return v.each(e.split(y),function(e,n){t[n]=!0}),t}function H(e,n,r){if(r===t&&e.nodeType===1){var i="data-"+n.replace(P,"-$1").toLowerCase();r=e.getAttribute(i);if(typeof r=="string"){try{r=r==="true"?!0:r==="false"?!1:r==="null"?null:+r+""===r?+r:D.test(r)?v.parseJSON(r):r}catch(s){}v.data(e,n,r)}else r=t}return r}function B(e){var t;for(t in e){if(t==="data"&&v.isEmptyObject(e[t]))continue;if(t!=="toJSON")return!1}return!0}function et(){return!1}function tt(){return!0}function ut(e){return!e||!e.parentNode||e.parentNode.nodeType===11}function at(e,t){do e=e[t];while(e&&e.nodeType!==1);return e}function ft(e,t,n){t=t||0;if(v.isFunction(t))return v.grep(e,function(e,r){var i=!!t.call(e,r,e);return i===n});if(t.nodeType)return v.grep(e,function(e,r){return e===t===n});if(typeof t=="string"){var r=v.grep(e,function(e){return e.nodeType===1});if(it.test(t))return v.filter(t,r,!n);t=v.filter(t,r)}return v.grep(e,function(e,r){return v.inArray(e,t)>=0===n})}function lt(e){var t=ct.split("|"),n=e.createDocumentFragment();if(n.createElement)while(t.length)n.createElement(t.pop());return n}function Lt(e,t){return e.getElementsByTagName(t)[0]||e.appendChild(e.ownerDocument.createElement(t))}function At(e,t){if(t.nodeType!==1||!v.hasData(e))return;var n,r,i,s=v._data(e),o=v._data(t,s),u=s.events;if(u){delete o.handle,o.events={};for(n in u)for(r=0,i=u[n].length;r<i;r++)v.event.add(t,n,u[n][r])}o.data&&(o.data=v.extend({},o.data))}function Ot(e,t){var n;if(t.nodeType!==1)return;t.clearAttributes&&t.clearAttributes(),t.mergeAttributes&&t.mergeAttributes(e),n=t.nodeName.toLowerCase(),n==="object"?(t.parentNode&&(t.outerHTML=e.outerHTML),v.support.html5Clone&&e.innerHTML&&!v.trim(t.innerHTML)&&(t.innerHTML=e.innerHTML)):n==="input"&&Et.test(e.type)?(t.defaultChecked=t.checked=e.checked,t.value!==e.value&&(t.value=e.value)):n==="option"?t.selected=e.defaultSelected:n==="input"||n==="textarea"?t.defaultValue=e.defaultValue:n==="script"&&t.text!==e.text&&(t.text=e.text),t.removeAttribute(v.expando)}function Mt(e){return typeof e.getElementsByTagName!="undefined"?e.getElementsByTagName("*"):typeof e.querySelectorAll!="undefined"?e.querySelectorAll("*"):[]}function _t(e){Et.test(e.type)&&(e.defaultChecked=e.checked)}function Qt(e,t){if(t in e)return t;var n=t.charAt(0).toUpperCase()+t.slice(1),r=t,i=Jt.length;while(i--){t=Jt[i]+n;if(t in e)return t}return r}function Gt(e,t){return e=t||e,v.css(e,"display")==="none"||!v.contains(e.ownerDocument,e)}function Yt(e,t){var n,r,i=[],s=0,o=e.length;for(;s<o;s++){n=e[s];if(!n.style)continue;i[s]=v._data(n,"olddisplay"),t?(!i[s]&&n.style.display==="none"&&(n.style.display=""),n.style.display===""&&Gt(n)&&(i[s]=v._data(n,"olddisplay",nn(n.nodeName)))):(r=Dt(n,"display"),!i[s]&&r!=="none"&&v._data(n,"olddisplay",r))}for(s=0;s<o;s++){n=e[s];if(!n.style)continue;if(!t||n.style.display==="none"||n.style.display==="")n.style.display=t?i[s]||"":"none"}return e}function Zt(e,t,n){var r=Rt.exec(t);return r?Math.max(0,r[1]-(n||0))+(r[2]||"px"):t}function en(e,t,n,r){var i=n===(r?"border":"content")?4:t==="width"?1:0,s=0;for(;i<4;i+=2)n==="margin"&&(s+=v.css(e,n+$t[i],!0)),r?(n==="content"&&(s-=parseFloat(Dt(e,"padding"+$t[i]))||0),n!=="margin"&&(s-=parseFloat(Dt(e,"border"+$t[i]+"Width"))||0)):(s+=parseFloat(Dt(e,"padding"+$t[i]))||0,n!=="padding"&&(s+=parseFloat(Dt(e,"border"+$t[i]+"Width"))||0));return s}function tn(e,t,n){var r=t==="width"?e.offsetWidth:e.offsetHeight,i=!0,s=v.support.boxSizing&&v.css(e,"boxSizing")==="border-box";if(r<=0||r==null){r=Dt(e,t);if(r<0||r==null)r=e.style[t];if(Ut.test(r))return r;i=s&&(v.support.boxSizingReliable||r===e.style[t]),r=parseFloat(r)||0}return r+en(e,t,n||(s?"border":"content"),i)+"px"}function nn(e){if(Wt[e])return Wt[e];var t=v("<"+e+">").appendTo(i.body),n=t.css("display");t.remove();if(n==="none"||n===""){Pt=i.body.appendChild(Pt||v.extend(i.createElement("iframe"),{frameBorder:0,width:0,height:0}));if(!Ht||!Pt.createElement)Ht=(Pt.contentWindow||Pt.contentDocument).document,Ht.write("<!doctype html><html><body>"),Ht.close();t=Ht.body.appendChild(Ht.createElement(e)),n=Dt(t,"display"),i.body.removeChild(Pt)}return Wt[e]=n,n}function fn(e,t,n,r){var i;if(v.isArray(t))v.each(t,function(t,i){n||sn.test(e)?r(e,i):fn(e+"["+(typeof i=="object"?t:"")+"]",i,n,r)});else if(!n&&v.type(t)==="object")for(i in t)fn(e+"["+i+"]",t[i],n,r);else r(e,t)}function Cn(e){return function(t,n){typeof t!="string"&&(n=t,t="*");var r,i,s,o=t.toLowerCase().split(y),u=0,a=o.length;if(v.isFunction(n))for(;u<a;u++)r=o[u],s=/^\+/.test(r),s&&(r=r.substr(1)||"*"),i=e[r]=e[r]||[],i[s?"unshift":"push"](n)}}function kn(e,n,r,i,s,o){s=s||n.dataTypes[0],o=o||{},o[s]=!0;var u,a=e[s],f=0,l=a?a.length:0,c=e===Sn;for(;f<l&&(c||!u);f++)u=a[f](n,r,i),typeof u=="string"&&(!c||o[u]?u=t:(n.dataTypes.unshift(u),u=kn(e,n,r,i,u,o)));return(c||!u)&&!o["*"]&&(u=kn(e,n,r,i,"*",o)),u}function Ln(e,n){var r,i,s=v.ajaxSettings.flatOptions||{};for(r in n)n[r]!==t&&((s[r]?e:i||(i={}))[r]=n[r]);i&&v.extend(!0,e,i)}function An(e,n,r){var i,s,o,u,a=e.contents,f=e.dataTypes,l=e.responseFields;for(s in l)s in r&&(n[l[s]]=r[s]);while(f[0]==="*")f.shift(),i===t&&(i=e.mimeType||n.getResponseHeader("content-type"));if(i)for(s in a)if(a[s]&&a[s].test(i)){f.unshift(s);break}if(f[0]in r)o=f[0];else{for(s in r){if(!f[0]||e.converters[s+" "+f[0]]){o=s;break}u||(u=s)}o=o||u}if(o)return o!==f[0]&&f.unshift(o),r[o]}function On(e,t){var n,r,i,s,o=e.dataTypes.slice(),u=o[0],a={},f=0;e.dataFilter&&(t=e.dataFilter(t,e.dataType));if(o[1])for(n in e.converters)a[n.toLowerCase()]=e.converters[n];for(;i=o[++f];)if(i!=="*"){if(u!=="*"&&u!==i){n=a[u+" "+i]||a["* "+i];if(!n)for(r in a){s=r.split(" ");if(s[1]===i){n=a[u+" "+s[0]]||a["* "+s[0]];if(n){n===!0?n=a[r]:a[r]!==!0&&(i=s[0],o.splice(f--,0,i));break}}}if(n!==!0)if(n&&e["throws"])t=n(t);else try{t=n(t)}catch(l){return{state:"parsererror",error:n?l:"No conversion from "+u+" to "+i}}}u=i}return{state:"success",data:t}}function Fn(){try{return new e.XMLHttpRequest}catch(t){}}function In(){try{return new e.ActiveXObject("Microsoft.XMLHTTP")}catch(t){}}function $n(){return setTimeout(function(){qn=t},0),qn=v.now()}function Jn(e,t){v.each(t,function(t,n){var r=(Vn[t]||[]).concat(Vn["*"]),i=0,s=r.length;for(;i<s;i++)if(r[i].call(e,t,n))return})}function Kn(e,t,n){var r,i=0,s=0,o=Xn.length,u=v.Deferred().always(function(){delete a.elem}),a=function(){var t=qn||$n(),n=Math.max(0,f.startTime+f.duration-t),r=n/f.duration||0,i=1-r,s=0,o=f.tweens.length;for(;s<o;s++)f.tweens[s].run(i);return u.notifyWith(e,[f,i,n]),i<1&&o?n:(u.resolveWith(e,[f]),!1)},f=u.promise({elem:e,props:v.extend({},t),opts:v.extend(!0,{specialEasing:{}},n),originalProperties:t,originalOptions:n,startTime:qn||$n(),duration:n.duration,tweens:[],createTween:function(t,n,r){var i=v.Tween(e,f.opts,t,n,f.opts.specialEasing[t]||f.opts.easing);return f.tweens.push(i),i},stop:function(t){var n=0,r=t?f.tweens.length:0;for(;n<r;n++)f.tweens[n].run(1);return t?u.resolveWith(e,[f,t]):u.rejectWith(e,[f,t]),this}}),l=f.props;Qn(l,f.opts.specialEasing);for(;i<o;i++){r=Xn[i].call(f,e,l,f.opts);if(r)return r}return Jn(f,l),v.isFunction(f.opts.start)&&f.opts.start.call(e,f),v.fx.timer(v.extend(a,{anim:f,queue:f.opts.queue,elem:e})),f.progress(f.opts.progress).done(f.opts.done,f.opts.complete).fail(f.opts.fail).always(f.opts.always)}function Qn(e,t){var n,r,i,s,o;for(n in e){r=v.camelCase(n),i=t[r],s=e[n],v.isArray(s)&&(i=s[1],s=e[n]=s[0]),n!==r&&(e[r]=s,delete e[n]),o=v.cssHooks[r];if(o&&"expand"in o){s=o.expand(s),delete e[r];for(n in s)n in e||(e[n]=s[n],t[n]=i)}else t[r]=i}}function Gn(e,t,n){var r,i,s,o,u,a,f,l,c,h=this,p=e.style,d={},m=[],g=e.nodeType&&Gt(e);n.queue||(l=v._queueHooks(e,"fx"),l.unqueued==null&&(l.unqueued=0,c=l.empty.fire,l.empty.fire=function(){l.unqueued||c()}),l.unqueued++,h.always(function(){h.always(function(){l.unqueued--,v.queue(e,"fx").length||l.empty.fire()})})),e.nodeType===1&&("height"in t||"width"in t)&&(n.overflow=[p.overflow,p.overflowX,p.overflowY],v.css(e,"display")==="inline"&&v.css(e,"float")==="none"&&(!v.support.inlineBlockNeedsLayout||nn(e.nodeName)==="inline"?p.display="inline-block":p.zoom=1)),n.overflow&&(p.overflow="hidden",v.support.shrinkWrapBlocks||h.done(function(){p.overflow=n.overflow[0],p.overflowX=n.overflow[1],p.overflowY=n.overflow[2]}));for(r in t){s=t[r];if(Un.exec(s)){delete t[r],a=a||s==="toggle";if(s===(g?"hide":"show"))continue;m.push(r)}}o=m.length;if(o){u=v._data(e,"fxshow")||v._data(e,"fxshow",{}),"hidden"in u&&(g=u.hidden),a&&(u.hidden=!g),g?v(e).show():h.done(function(){v(e).hide()}),h.done(function(){var t;v.removeData(e,"fxshow",!0);for(t in d)v.style(e,t,d[t])});for(r=0;r<o;r++)i=m[r],f=h.createTween(i,g?u[i]:0),d[i]=u[i]||v.style(e,i),i in u||(u[i]=f.start,g&&(f.end=f.start,f.start=i==="width"||i==="height"?1:0))}}function Yn(e,t,n,r,i){return new Yn.prototype.init(e,t,n,r,i)}function Zn(e,t){var n,r={height:e},i=0;t=t?1:0;for(;i<4;i+=2-t)n=$t[i],r["margin"+n]=r["padding"+n]=e;return t&&(r.opacity=r.width=e),r}function tr(e){return v.isWindow(e)?e:e.nodeType===9?e.defaultView||e.parentWindow:!1}var n,r,i=e.document,s=e.location,o=e.navigator,u=e.jQuery,a=e.$,f=Array.prototype.push,l=Array.prototype.slice,c=Array.prototype.indexOf,h=Object.prototype.toString,p=Object.prototype.hasOwnProperty,d=String.prototype.trim,v=function(e,t){return new v.fn.init(e,t,n)},m=/[\-+]?(?:\d*\.|)\d+(?:[eE][\-+]?\d+|)/.source,g=/\S/,y=/\s+/,b=/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g,w=/^(?:[^#<]*(<[\w\W]+>)[^>]*$|#([\w\-]*)$)/,E=/^<(\w+)\s*\/?>(?:<\/\1>|)$/,S=/^[\],:{}\s]*$/,x=/(?:^|:|,)(?:\s*\[)+/g,T=/\\(?:["\\\/bfnrt]|u[\da-fA-F]{4})/g,N=/"[^"\\\r\n]*"|true|false|null|-?(?:\d\d*\.|)\d+(?:[eE][\-+]?\d+|)/g,C=/^-ms-/,k=/-([\da-z])/gi,L=function(e,t){return(t+"").toUpperCase()},A=function(){i.addEventListener?(i.removeEventListener("DOMContentLoaded",A,!1),v.ready()):i.readyState==="complete"&&(i.detachEvent("onreadystatechange",A),v.ready())},O={};v.fn=v.prototype={constructor:v,init:function(e,n,r){var s,o,u,a;if(!e)return this;if(e.nodeType)return this.context=this[0]=e,this.length=1,this;if(typeof e=="string"){e.charAt(0)==="<"&&e.charAt(e.length-1)===">"&&e.length>=3?s=[null,e,null]:s=w.exec(e);if(s&&(s[1]||!n)){if(s[1])return n=n instanceof v?n[0]:n,a=n&&n.nodeType?n.ownerDocument||n:i,e=v.parseHTML(s[1],a,!0),E.test(s[1])&&v.isPlainObject(n)&&this.attr.call(e,n,!0),v.merge(this,e);o=i.getElementById(s[2]);if(o&&o.parentNode){if(o.id!==s[2])return r.find(e);this.length=1,this[0]=o}return this.context=i,this.selector=e,this}return!n||n.jquery?(n||r).find(e):this.constructor(n).find(e)}return v.isFunction(e)?r.ready(e):(e.selector!==t&&(this.selector=e.selector,this.context=e.context),v.makeArray(e,this))},selector:"",jquery:"1.8.3",length:0,size:function(){return this.length},toArray:function(){return l.call(this)},get:function(e){return e==null?this.toArray():e<0?this[this.length+e]:this[e]},pushStack:function(e,t,n){var r=v.merge(this.constructor(),e);return r.prevObject=this,r.context=this.context,t==="find"?r.selector=this.selector+(this.selector?" ":"")+n:t&&(r.selector=this.selector+"."+t+"("+n+")"),r},each:function(e,t){return v.each(this,e,t)},ready:function(e){return v.ready.promise().done(e),this},eq:function(e){return e=+e,e===-1?this.slice(e):this.slice(e,e+1)},first:function(){return this.eq(0)},last:function(){return this.eq(-1)},slice:function(){return this.pushStack(l.apply(this,arguments),"slice",l.call(arguments).join(","))},map:function(e){return this.pushStack(v.map(this,function(t,n){return e.call(t,n,t)}))},end:function(){return this.prevObject||this.constructor(null)},push:f,sort:[].sort,splice:[].splice},v.fn.init.prototype=v.fn,v.extend=v.fn.extend=function(){var e,n,r,i,s,o,u=arguments[0]||{},a=1,f=arguments.length,l=!1;typeof u=="boolean"&&(l=u,u=arguments[1]||{},a=2),typeof u!="object"&&!v.isFunction(u)&&(u={}),f===a&&(u=this,--a);for(;a<f;a++)if((e=arguments[a])!=null)for(n in e){r=u[n],i=e[n];if(u===i)continue;l&&i&&(v.isPlainObject(i)||(s=v.isArray(i)))?(s?(s=!1,o=r&&v.isArray(r)?r:[]):o=r&&v.isPlainObject(r)?r:{},u[n]=v.extend(l,o,i)):i!==t&&(u[n]=i)}return u},v.extend({noConflict:function(t){return e.$===v&&(e.$=a),t&&e.jQuery===v&&(e.jQuery=u),v},isReady:!1,readyWait:1,holdReady:function(e){e?v.readyWait++:v.ready(!0)},ready:function(e){if(e===!0?--v.readyWait:v.isReady)return;if(!i.body)return setTimeout(v.ready,1);v.isReady=!0;if(e!==!0&&--v.readyWait>0)return;r.resolveWith(i,[v]),v.fn.trigger&&v(i).trigger("ready").off("ready")},isFunction:function(e){return v.type(e)==="function"},isArray:Array.isArray||function(e){return v.type(e)==="array"},isWindow:function(e){return e!=null&&e==e.window},isNumeric:function(e){return!isNaN(parseFloat(e))&&isFinite(e)},type:function(e){return e==null?String(e):O[h.call(e)]||"object"},isPlainObject:function(e){if(!e||v.type(e)!=="object"||e.nodeType||v.isWindow(e))return!1;try{if(e.constructor&&!p.call(e,"constructor")&&!p.call(e.constructor.prototype,"isPrototypeOf"))return!1}catch(n){return!1}var r;for(r in e);return r===t||p.call(e,r)},isEmptyObject:function(e){var t;for(t in e)return!1;return!0},error:function(e){throw new Error(e)},parseHTML:function(e,t,n){var r;return!e||typeof e!="string"?null:(typeof t=="boolean"&&(n=t,t=0),t=t||i,(r=E.exec(e))?[t.createElement(r[1])]:(r=v.buildFragment([e],t,n?null:[]),v.merge([],(r.cacheable?v.clone(r.fragment):r.fragment).childNodes)))},parseJSON:function(t){if(!t||typeof t!="string")return null;t=v.trim(t);if(e.JSON&&e.JSON.parse)return e.JSON.parse(t);if(S.test(t.replace(T,"@").replace(N,"]").replace(x,"")))return(new Function("return "+t))();v.error("Invalid JSON: "+t)},parseXML:function(n){var r,i;if(!n||typeof n!="string")return null;try{e.DOMParser?(i=new DOMParser,r=i.parseFromString(n,"text/xml")):(r=new ActiveXObject("Microsoft.XMLDOM"),r.async="false",r.loadXML(n))}catch(s){r=t}return(!r||!r.documentElement||r.getElementsByTagName("parsererror").length)&&v.error("Invalid XML: "+n),r},noop:function(){},globalEval:function(t){t&&g.test(t)&&(e.execScript||function(t){e.eval.call(e,t)})(t)},camelCase:function(e){return e.replace(C,"ms-").replace(k,L)},nodeName:function(e,t){return e.nodeName&&e.nodeName.toLowerCase()===t.toLowerCase()},each:function(e,n,r){var i,s=0,o=e.length,u=o===t||v.isFunction(e);if(r){if(u){for(i in e)if(n.apply(e[i],r)===!1)break}else for(;s<o;)if(n.apply(e[s++],r)===!1)break}else if(u){for(i in e)if(n.call(e[i],i,e[i])===!1)break}else for(;s<o;)if(n.call(e[s],s,e[s++])===!1)break;return e},trim:d&&!d.call("\ufeff\u00a0")?function(e){return e==null?"":d.call(e)}:function(e){return e==null?"":(e+"").replace(b,"")},makeArray:function(e,t){var n,r=t||[];return e!=null&&(n=v.type(e),e.length==null||n==="string"||n==="function"||n==="regexp"||v.isWindow(e)?f.call(r,e):v.merge(r,e)),r},inArray:function(e,t,n){var r;if(t){if(c)return c.call(t,e,n);r=t.length,n=n?n<0?Math.max(0,r+n):n:0;for(;n<r;n++)if(n in t&&t[n]===e)return n}return-1},merge:function(e,n){var r=n.length,i=e.length,s=0;if(typeof r=="number")for(;s<r;s++)e[i++]=n[s];else while(n[s]!==t)e[i++]=n[s++];return e.length=i,e},grep:function(e,t,n){var r,i=[],s=0,o=e.length;n=!!n;for(;s<o;s++)r=!!t(e[s],s),n!==r&&i.push(e[s]);return i},map:function(e,n,r){var i,s,o=[],u=0,a=e.length,f=e instanceof v||a!==t&&typeof a=="number"&&(a>0&&e[0]&&e[a-1]||a===0||v.isArray(e));if(f)for(;u<a;u++)i=n(e[u],u,r),i!=null&&(o[o.length]=i);else for(s in e)i=n(e[s],s,r),i!=null&&(o[o.length]=i);return o.concat.apply([],o)},guid:1,proxy:function(e,n){var r,i,s;return typeof n=="string"&&(r=e[n],n=e,e=r),v.isFunction(e)?(i=l.call(arguments,2),s=function(){return e.apply(n,i.concat(l.call(arguments)))},s.guid=e.guid=e.guid||v.guid++,s):t},access:function(e,n,r,i,s,o,u){var a,f=r==null,l=0,c=e.length;if(r&&typeof r=="object"){for(l in r)v.access(e,n,l,r[l],1,o,i);s=1}else if(i!==t){a=u===t&&v.isFunction(i),f&&(a?(a=n,n=function(e,t,n){return a.call(v(e),n)}):(n.call(e,i),n=null));if(n)for(;l<c;l++)n(e[l],r,a?i.call(e[l],l,n(e[l],r)):i,u);s=1}return s?e:f?n.call(e):c?n(e[0],r):o},now:function(){return(new Date).getTime()}}),v.ready.promise=function(t){if(!r){r=v.Deferred();if(i.readyState==="complete")setTimeout(v.ready,1);else if(i.addEventListener)i.addEventListener("DOMContentLoaded",A,!1),e.addEventListener("load",v.ready,!1);else{i.attachEvent("onreadystatechange",A),e.attachEvent("onload",v.ready);var n=!1;try{n=e.frameElement==null&&i.documentElement}catch(s){}n&&n.doScroll&&function o(){if(!v.isReady){try{n.doScroll("left")}catch(e){return setTimeout(o,50)}v.ready()}}()}}return r.promise(t)},v.each("Boolean Number String Function Array Date RegExp Object".split(" "),function(e,t){O["[object "+t+"]"]=t.toLowerCase()}),n=v(i);var M={};v.Callbacks=function(e){e=typeof e=="string"?M[e]||_(e):v.extend({},e);var n,r,i,s,o,u,a=[],f=!e.once&&[],l=function(t){n=e.memory&&t,r=!0,u=s||0,s=0,o=a.length,i=!0;for(;a&&u<o;u++)if(a[u].apply(t[0],t[1])===!1&&e.stopOnFalse){n=!1;break}i=!1,a&&(f?f.length&&l(f.shift()):n?a=[]:c.disable())},c={add:function(){if(a){var t=a.length;(function r(t){v.each(t,function(t,n){var i=v.type(n);i==="function"?(!e.unique||!c.has(n))&&a.push(n):n&&n.length&&i!=="string"&&r(n)})})(arguments),i?o=a.length:n&&(s=t,l(n))}return this},remove:function(){return a&&v.each(arguments,function(e,t){var n;while((n=v.inArray(t,a,n))>-1)a.splice(n,1),i&&(n<=o&&o--,n<=u&&u--)}),this},has:function(e){return v.inArray(e,a)>-1},empty:function(){return a=[],this},disable:function(){return a=f=n=t,this},disabled:function(){return!a},lock:function(){return f=t,n||c.disable(),this},locked:function(){return!f},fireWith:function(e,t){return t=t||[],t=[e,t.slice?t.slice():t],a&&(!r||f)&&(i?f.push(t):l(t)),this},fire:function(){return c.fireWith(this,arguments),this},fired:function(){return!!r}};return c},v.extend({Deferred:function(e){var t=[["resolve","done",v.Callbacks("once memory"),"resolved"],["reject","fail",v.Callbacks("once memory"),"rejected"],["notify","progress",v.Callbacks("memory")]],n="pending",r={state:function(){return n},always:function(){return i.done(arguments).fail(arguments),this},then:function(){var e=arguments;return v.Deferred(function(n){v.each(t,function(t,r){var s=r[0],o=e[t];i[r[1]](v.isFunction(o)?function(){var e=o.apply(this,arguments);e&&v.isFunction(e.promise)?e.promise().done(n.resolve).fail(n.reject).progress(n.notify):n[s+"With"](this===i?n:this,[e])}:n[s])}),e=null}).promise()},promise:function(e){return e!=null?v.extend(e,r):r}},i={};return r.pipe=r.then,v.each(t,function(e,s){var o=s[2],u=s[3];r[s[1]]=o.add,u&&o.add(function(){n=u},t[e^1][2].disable,t[2][2].lock),i[s[0]]=o.fire,i[s[0]+"With"]=o.fireWith}),r.promise(i),e&&e.call(i,i),i},when:function(e){var t=0,n=l.call(arguments),r=n.length,i=r!==1||e&&v.isFunction(e.promise)?r:0,s=i===1?e:v.Deferred(),o=function(e,t,n){return function(r){t[e]=this,n[e]=arguments.length>1?l.call(arguments):r,n===u?s.notifyWith(t,n):--i||s.resolveWith(t,n)}},u,a,f;if(r>1){u=new Array(r),a=new Array(r),f=new Array(r);for(;t<r;t++)n[t]&&v.isFunction(n[t].promise)?n[t].promise().done(o(t,f,n)).fail(s.reject).progress(o(t,a,u)):--i}return i||s.resolveWith(f,n),s.promise()}}),v.support=function(){var t,n,r,s,o,u,a,f,l,c,h,p=i.createElement("div");p.setAttribute("className","t"),p.innerHTML="  <link/><table></table><a href='/a'>a</a><input type='checkbox'/>",n=p.getElementsByTagName("*"),r=p.getElementsByTagName("a")[0];if(!n||!r||!n.length)return{};s=i.createElement("select"),o=s.appendChild(i.createElement("option")),u=p.getElementsByTagName("input")[0],r.style.cssText="top:1px;float:left;opacity:.5",t={leadingWhitespace:p.firstChild.nodeType===3,tbody:!p.getElementsByTagName("tbody").length,htmlSerialize:!!p.getElementsByTagName("link").length,style:/top/.test(r.getAttribute("style")),hrefNormalized:r.getAttribute("href")==="/a",opacity:/^0.5/.test(r.style.opacity),cssFloat:!!r.style.cssFloat,checkOn:u.value==="on",optSelected:o.selected,getSetAttribute:p.className!=="t",enctype:!!i.createElement("form").enctype,html5Clone:i.createElement("nav").cloneNode(!0).outerHTML!=="<:nav></:nav>",boxModel:i.compatMode==="CSS1Compat",submitBubbles:!0,changeBubbles:!0,focusinBubbles:!1,deleteExpando:!0,noCloneEvent:!0,inlineBlockNeedsLayout:!1,shrinkWrapBlocks:!1,reliableMarginRight:!0,boxSizingReliable:!0,pixelPosition:!1},u.checked=!0,t.noCloneChecked=u.cloneNode(!0).checked,s.disabled=!0,t.optDisabled=!o.disabled;try{delete p.test}catch(d){t.deleteExpando=!1}!p.addEventListener&&p.attachEvent&&p.fireEvent&&(p.attachEvent("onclick",h=function(){t.noCloneEvent=!1}),p.cloneNode(!0).fireEvent("onclick"),p.detachEvent("onclick",h)),u=i.createElement("input"),u.value="t",u.setAttribute("type","radio"),t.radioValue=u.value==="t",u.setAttribute("checked","checked"),u.setAttribute("name","t"),p.appendChild(u),a=i.createDocumentFragment(),a.appendChild(p.lastChild),t.checkClone=a.cloneNode(!0).cloneNode(!0).lastChild.checked,t.appendChecked=u.checked,a.removeChild(u),a.appendChild(p);if(p.attachEvent)for(l in{submit:!0,change:!0,focusin:!0})f="on"+l,c=f in p,c||(p.setAttribute(f,"return;"),c=typeof p[f]=="function"),t[l+"Bubbles"]=c;return v(function(){var n,r,s,o,u="padding:0;margin:0;border:0;display:block;overflow:hidden;",a=i.getElementsByTagName("body")[0];if(!a)return;n=i.createElement("div"),n.style.cssText="visibility:hidden;border:0;width:0;height:0;position:static;top:0;margin-top:1px",a.insertBefore(n,a.firstChild),r=i.createElement("div"),n.appendChild(r),r.innerHTML="<table><tr><td></td><td>t</td></tr></table>",s=r.getElementsByTagName("td"),s[0].style.cssText="padding:0;margin:0;border:0;display:none",c=s[0].offsetHeight===0,s[0].style.display="",s[1].style.display="none",t.reliableHiddenOffsets=c&&s[0].offsetHeight===0,r.innerHTML="",r.style.cssText="box-sizing:border-box;-moz-box-sizing:border-box;-webkit-box-sizing:border-box;padding:1px;border:1px;display:block;width:4px;margin-top:1%;position:absolute;top:1%;",t.boxSizing=r.offsetWidth===4,t.doesNotIncludeMarginInBodyOffset=a.offsetTop!==1,e.getComputedStyle&&(t.pixelPosition=(e.getComputedStyle(r,null)||{}).top!=="1%",t.boxSizingReliable=(e.getComputedStyle(r,null)||{width:"4px"}).width==="4px",o=i.createElement("div"),o.style.cssText=r.style.cssText=u,o.style.marginRight=o.style.width="0",r.style.width="1px",r.appendChild(o),t.reliableMarginRight=!parseFloat((e.getComputedStyle(o,null)||{}).marginRight)),typeof r.style.zoom!="undefined"&&(r.innerHTML="",r.style.cssText=u+"width:1px;padding:1px;display:inline;zoom:1",t.inlineBlockNeedsLayout=r.offsetWidth===3,r.style.display="block",r.style.overflow="visible",r.innerHTML="<div></div>",r.firstChild.style.width="5px",t.shrinkWrapBlocks=r.offsetWidth!==3,n.style.zoom=1),a.removeChild(n),n=r=s=o=null}),a.removeChild(p),n=r=s=o=u=a=p=null,t}();var D=/(?:\{[\s\S]*\}|\[[\s\S]*\])$/,P=/([A-Z])/g;v.extend({cache:{},deletedIds:[],uuid:0,expando:"jQuery"+(v.fn.jquery+Math.random()).replace(/\D/g,""),noData:{embed:!0,object:"clsid:D27CDB6E-AE6D-11cf-96B8-444553540000",applet:!0},hasData:function(e){return e=e.nodeType?v.cache[e[v.expando]]:e[v.expando],!!e&&!B(e)},data:function(e,n,r,i){if(!v.acceptData(e))return;var s,o,u=v.expando,a=typeof n=="string",f=e.nodeType,l=f?v.cache:e,c=f?e[u]:e[u]&&u;if((!c||!l[c]||!i&&!l[c].data)&&a&&r===t)return;c||(f?e[u]=c=v.deletedIds.pop()||v.guid++:c=u),l[c]||(l[c]={},f||(l[c].toJSON=v.noop));if(typeof n=="object"||typeof n=="function")i?l[c]=v.extend(l[c],n):l[c].data=v.extend(l[c].data,n);return s=l[c],i||(s.data||(s.data={}),s=s.data),r!==t&&(s[v.camelCase(n)]=r),a?(o=s[n],o==null&&(o=s[v.camelCase(n)])):o=s,o},removeData:function(e,t,n){if(!v.acceptData(e))return;var r,i,s,o=e.nodeType,u=o?v.cache:e,a=o?e[v.expando]:v.expando;if(!u[a])return;if(t){r=n?u[a]:u[a].data;if(r){v.isArray(t)||(t in r?t=[t]:(t=v.camelCase(t),t in r?t=[t]:t=t.split(" ")));for(i=0,s=t.length;i<s;i++)delete r[t[i]];if(!(n?B:v.isEmptyObject)(r))return}}if(!n){delete u[a].data;if(!B(u[a]))return}o?v.cleanData([e],!0):v.support.deleteExpando||u!=u.window?delete u[a]:u[a]=null},_data:function(e,t,n){return v.data(e,t,n,!0)},acceptData:function(e){var t=e.nodeName&&v.noData[e.nodeName.toLowerCase()];return!t||t!==!0&&e.getAttribute("classid")===t}}),v.fn.extend({data:function(e,n){var r,i,s,o,u,a=this[0],f=0,l=null;if(e===t){if(this.length){l=v.data(a);if(a.nodeType===1&&!v._data(a,"parsedAttrs")){s=a.attributes;for(u=s.length;f<u;f++)o=s[f].name,o.indexOf("data-")||(o=v.camelCase(o.substring(5)),H(a,o,l[o]));v._data(a,"parsedAttrs",!0)}}return l}return typeof e=="object"?this.each(function(){v.data(this,e)}):(r=e.split(".",2),r[1]=r[1]?"."+r[1]:"",i=r[1]+"!",v.access(this,function(n){if(n===t)return l=this.triggerHandler("getData"+i,[r[0]]),l===t&&a&&(l=v.data(a,e),l=H(a,e,l)),l===t&&r[1]?this.data(r[0]):l;r[1]=n,this.each(function(){var t=v(this);t.triggerHandler("setData"+i,r),v.data(this,e,n),t.triggerHandler("changeData"+i,r)})},null,n,arguments.length>1,null,!1))},removeData:function(e){return this.each(function(){v.removeData(this,e)})}}),v.extend({queue:function(e,t,n){var r;if(e)return t=(t||"fx")+"queue",r=v._data(e,t),n&&(!r||v.isArray(n)?r=v._data(e,t,v.makeArray(n)):r.push(n)),r||[]},dequeue:function(e,t){t=t||"fx";var n=v.queue(e,t),r=n.length,i=n.shift(),s=v._queueHooks(e,t),o=function(){v.dequeue(e,t)};i==="inprogress"&&(i=n.shift(),r--),i&&(t==="fx"&&n.unshift("inprogress"),delete s.stop,i.call(e,o,s)),!r&&s&&s.empty.fire()},_queueHooks:function(e,t){var n=t+"queueHooks";return v._data(e,n)||v._data(e,n,{empty:v.Callbacks("once memory").add(function(){v.removeData(e,t+"queue",!0),v.removeData(e,n,!0)})})}}),v.fn.extend({queue:function(e,n){var r=2;return typeof e!="string"&&(n=e,e="fx",r--),arguments.length<r?v.queue(this[0],e):n===t?this:this.each(function(){var t=v.queue(this,e,n);v._queueHooks(this,e),e==="fx"&&t[0]!=="inprogress"&&v.dequeue(this,e)})},dequeue:function(e){return this.each(function(){v.dequeue(this,e)})},delay:function(e,t){return e=v.fx?v.fx.speeds[e]||e:e,t=t||"fx",this.queue(t,function(t,n){var r=setTimeout(t,e);n.stop=function(){clearTimeout(r)}})},clearQueue:function(e){return this.queue(e||"fx",[])},promise:function(e,n){var r,i=1,s=v.Deferred(),o=this,u=this.length,a=function(){--i||s.resolveWith(o,[o])};typeof e!="string"&&(n=e,e=t),e=e||"fx";while(u--)r=v._data(o[u],e+"queueHooks"),r&&r.empty&&(i++,r.empty.add(a));return a(),s.promise(n)}});var j,F,I,q=/[\t\r\n]/g,R=/\r/g,U=/^(?:button|input)$/i,z=/^(?:button|input|object|select|textarea)$/i,W=/^a(?:rea|)$/i,X=/^(?:autofocus|autoplay|async|checked|controls|defer|disabled|hidden|loop|multiple|open|readonly|required|scoped|selected)$/i,V=v.support.getSetAttribute;v.fn.extend({attr:function(e,t){return v.access(this,v.attr,e,t,arguments.length>1)},removeAttr:function(e){return this.each(function(){v.removeAttr(this,e)})},prop:function(e,t){return v.access(this,v.prop,e,t,arguments.length>1)},removeProp:function(e){return e=v.propFix[e]||e,this.each(function(){try{this[e]=t,delete this[e]}catch(n){}})},addClass:function(e){var t,n,r,i,s,o,u;if(v.isFunction(e))return this.each(function(t){v(this).addClass(e.call(this,t,this.className))});if(e&&typeof e=="string"){t=e.split(y);for(n=0,r=this.length;n<r;n++){i=this[n];if(i.nodeType===1)if(!i.className&&t.length===1)i.className=e;else{s=" "+i.className+" ";for(o=0,u=t.length;o<u;o++)s.indexOf(" "+t[o]+" ")<0&&(s+=t[o]+" ");i.className=v.trim(s)}}}return this},removeClass:function(e){var n,r,i,s,o,u,a;if(v.isFunction(e))return this.each(function(t){v(this).removeClass(e.call(this,t,this.className))});if(e&&typeof e=="string"||e===t){n=(e||"").split(y);for(u=0,a=this.length;u<a;u++){i=this[u];if(i.nodeType===1&&i.className){r=(" "+i.className+" ").replace(q," ");for(s=0,o=n.length;s<o;s++)while(r.indexOf(" "+n[s]+" ")>=0)r=r.replace(" "+n[s]+" "," ");i.className=e?v.trim(r):""}}}return this},toggleClass:function(e,t){var n=typeof e,r=typeof t=="boolean";return v.isFunction(e)?this.each(function(n){v(this).toggleClass(e.call(this,n,this.className,t),t)}):this.each(function(){if(n==="string"){var i,s=0,o=v(this),u=t,a=e.split(y);while(i=a[s++])u=r?u:!o.hasClass(i),o[u?"addClass":"removeClass"](i)}else if(n==="undefined"||n==="boolean")this.className&&v._data(this,"__className__",this.className),this.className=this.className||e===!1?"":v._data(this,"__className__")||""})},hasClass:function(e){var t=" "+e+" ",n=0,r=this.length;for(;n<r;n++)if(this[n].nodeType===1&&(" "+this[n].className+" ").replace(q," ").indexOf(t)>=0)return!0;return!1},val:function(e){var n,r,i,s=this[0];if(!arguments.length){if(s)return n=v.valHooks[s.type]||v.valHooks[s.nodeName.toLowerCase()],n&&"get"in n&&(r=n.get(s,"value"))!==t?r:(r=s.value,typeof r=="string"?r.replace(R,""):r==null?"":r);return}return i=v.isFunction(e),this.each(function(r){var s,o=v(this);if(this.nodeType!==1)return;i?s=e.call(this,r,o.val()):s=e,s==null?s="":typeof s=="number"?s+="":v.isArray(s)&&(s=v.map(s,function(e){return e==null?"":e+""})),n=v.valHooks[this.type]||v.valHooks[this.nodeName.toLowerCase()];if(!n||!("set"in n)||n.set(this,s,"value")===t)this.value=s})}}),v.extend({valHooks:{option:{get:function(e){var t=e.attributes.value;return!t||t.specified?e.value:e.text}},select:{get:function(e){var t,n,r=e.options,i=e.selectedIndex,s=e.type==="select-one"||i<0,o=s?null:[],u=s?i+1:r.length,a=i<0?u:s?i:0;for(;a<u;a++){n=r[a];if((n.selected||a===i)&&(v.support.optDisabled?!n.disabled:n.getAttribute("disabled")===null)&&(!n.parentNode.disabled||!v.nodeName(n.parentNode,"optgroup"))){t=v(n).val();if(s)return t;o.push(t)}}return o},set:function(e,t){var n=v.makeArray(t);return v(e).find("option").each(function(){this.selected=v.inArray(v(this).val(),n)>=0}),n.length||(e.selectedIndex=-1),n}}},attrFn:{},attr:function(e,n,r,i){var s,o,u,a=e.nodeType;if(!e||a===3||a===8||a===2)return;if(i&&v.isFunction(v.fn[n]))return v(e)[n](r);if(typeof e.getAttribute=="undefined")return v.prop(e,n,r);u=a!==1||!v.isXMLDoc(e),u&&(n=n.toLowerCase(),o=v.attrHooks[n]||(X.test(n)?F:j));if(r!==t){if(r===null){v.removeAttr(e,n);return}return o&&"set"in o&&u&&(s=o.set(e,r,n))!==t?s:(e.setAttribute(n,r+""),r)}return o&&"get"in o&&u&&(s=o.get(e,n))!==null?s:(s=e.getAttribute(n),s===null?t:s)},removeAttr:function(e,t){var n,r,i,s,o=0;if(t&&e.nodeType===1){r=t.split(y);for(;o<r.length;o++)i=r[o],i&&(n=v.propFix[i]||i,s=X.test(i),s||v.attr(e,i,""),e.removeAttribute(V?i:n),s&&n in e&&(e[n]=!1))}},attrHooks:{type:{set:function(e,t){if(U.test(e.nodeName)&&e.parentNode)v.error("type property can't be changed");else if(!v.support.radioValue&&t==="radio"&&v.nodeName(e,"input")){var n=e.value;return e.setAttribute("type",t),n&&(e.value=n),t}}},value:{get:function(e,t){return j&&v.nodeName(e,"button")?j.get(e,t):t in e?e.value:null},set:function(e,t,n){if(j&&v.nodeName(e,"button"))return j.set(e,t,n);e.value=t}}},propFix:{tabindex:"tabIndex",readonly:"readOnly","for":"htmlFor","class":"className",maxlength:"maxLength",cellspacing:"cellSpacing",cellpadding:"cellPadding",rowspan:"rowSpan",colspan:"colSpan",usemap:"useMap",frameborder:"frameBorder",contenteditable:"contentEditable"},prop:function(e,n,r){var i,s,o,u=e.nodeType;if(!e||u===3||u===8||u===2)return;return o=u!==1||!v.isXMLDoc(e),o&&(n=v.propFix[n]||n,s=v.propHooks[n]),r!==t?s&&"set"in s&&(i=s.set(e,r,n))!==t?i:e[n]=r:s&&"get"in s&&(i=s.get(e,n))!==null?i:e[n]},propHooks:{tabIndex:{get:function(e){var n=e.getAttributeNode("tabindex");return n&&n.specified?parseInt(n.value,10):z.test(e.nodeName)||W.test(e.nodeName)&&e.href?0:t}}}}),F={get:function(e,n){var r,i=v.prop(e,n);return i===!0||typeof i!="boolean"&&(r=e.getAttributeNode(n))&&r.nodeValue!==!1?n.toLowerCase():t},set:function(e,t,n){var r;return t===!1?v.removeAttr(e,n):(r=v.propFix[n]||n,r in e&&(e[r]=!0),e.setAttribute(n,n.toLowerCase())),n}},V||(I={name:!0,id:!0,coords:!0},j=v.valHooks.button={get:function(e,n){var r;return r=e.getAttributeNode(n),r&&(I[n]?r.value!=="":r.specified)?r.value:t},set:function(e,t,n){var r=e.getAttributeNode(n);return r||(r=i.createAttribute(n),e.setAttributeNode(r)),r.value=t+""}},v.each(["width","height"],function(e,t){v.attrHooks[t]=v.extend(v.attrHooks[t],{set:function(e,n){if(n==="")return e.setAttribute(t,"auto"),n}})}),v.attrHooks.contenteditable={get:j.get,set:function(e,t,n){t===""&&(t="false"),j.set(e,t,n)}}),v.support.hrefNormalized||v.each(["href","src","width","height"],function(e,n){v.attrHooks[n]=v.extend(v.attrHooks[n],{get:function(e){var r=e.getAttribute(n,2);return r===null?t:r}})}),v.support.style||(v.attrHooks.style={get:function(e){return e.style.cssText.toLowerCase()||t},set:function(e,t){return e.style.cssText=t+""}}),v.support.optSelected||(v.propHooks.selected=v.extend(v.propHooks.selected,{get:function(e){var t=e.parentNode;return t&&(t.selectedIndex,t.parentNode&&t.parentNode.selectedIndex),null}})),v.support.enctype||(v.propFix.enctype="encoding"),v.support.checkOn||v.each(["radio","checkbox"],function(){v.valHooks[this]={get:function(e){return e.getAttribute("value")===null?"on":e.value}}}),v.each(["radio","checkbox"],function(){v.valHooks[this]=v.extend(v.valHooks[this],{set:function(e,t){if(v.isArray(t))return e.checked=v.inArray(v(e).val(),t)>=0}})});var $=/^(?:textarea|input|select)$/i,J=/^([^\.]*|)(?:\.(.+)|)$/,K=/(?:^|\s)hover(\.\S+|)\b/,Q=/^key/,G=/^(?:mouse|contextmenu)|click/,Y=/^(?:focusinfocus|focusoutblur)$/,Z=function(e){return v.event.special.hover?e:e.replace(K,"mouseenter$1 mouseleave$1")};v.event={add:function(e,n,r,i,s){var o,u,a,f,l,c,h,p,d,m,g;if(e.nodeType===3||e.nodeType===8||!n||!r||!(o=v._data(e)))return;r.handler&&(d=r,r=d.handler,s=d.selector),r.guid||(r.guid=v.guid++),a=o.events,a||(o.events=a={}),u=o.handle,u||(o.handle=u=function(e){return typeof v=="undefined"||!!e&&v.event.triggered===e.type?t:v.event.dispatch.apply(u.elem,arguments)},u.elem=e),n=v.trim(Z(n)).split(" ");for(f=0;f<n.length;f++){l=J.exec(n[f])||[],c=l[1],h=(l[2]||"").split(".").sort(),g=v.event.special[c]||{},c=(s?g.delegateType:g.bindType)||c,g=v.event.special[c]||{},p=v.extend({type:c,origType:l[1],data:i,handler:r,guid:r.guid,selector:s,needsContext:s&&v.expr.match.needsContext.test(s),namespace:h.join(".")},d),m=a[c];if(!m){m=a[c]=[],m.delegateCount=0;if(!g.setup||g.setup.call(e,i,h,u)===!1)e.addEventListener?e.addEventListener(c,u,!1):e.attachEvent&&e.attachEvent("on"+c,u)}g.add&&(g.add.call(e,p),p.handler.guid||(p.handler.guid=r.guid)),s?m.splice(m.delegateCount++,0,p):m.push(p),v.event.global[c]=!0}e=null},global:{},remove:function(e,t,n,r,i){var s,o,u,a,f,l,c,h,p,d,m,g=v.hasData(e)&&v._data(e);if(!g||!(h=g.events))return;t=v.trim(Z(t||"")).split(" ");for(s=0;s<t.length;s++){o=J.exec(t[s])||[],u=a=o[1],f=o[2];if(!u){for(u in h)v.event.remove(e,u+t[s],n,r,!0);continue}p=v.event.special[u]||{},u=(r?p.delegateType:p.bindType)||u,d=h[u]||[],l=d.length,f=f?new RegExp("(^|\\.)"+f.split(".").sort().join("\\.(?:.*\\.|)")+"(\\.|$)"):null;for(c=0;c<d.length;c++)m=d[c],(i||a===m.origType)&&(!n||n.guid===m.guid)&&(!f||f.test(m.namespace))&&(!r||r===m.selector||r==="**"&&m.selector)&&(d.splice(c--,1),m.selector&&d.delegateCount--,p.remove&&p.remove.call(e,m));d.length===0&&l!==d.length&&((!p.teardown||p.teardown.call(e,f,g.handle)===!1)&&v.removeEvent(e,u,g.handle),delete h[u])}v.isEmptyObject(h)&&(delete g.handle,v.removeData(e,"events",!0))},customEvent:{getData:!0,setData:!0,changeData:!0},trigger:function(n,r,s,o){if(!s||s.nodeType!==3&&s.nodeType!==8){var u,a,f,l,c,h,p,d,m,g,y=n.type||n,b=[];if(Y.test(y+v.event.triggered))return;y.indexOf("!")>=0&&(y=y.slice(0,-1),a=!0),y.indexOf(".")>=0&&(b=y.split("."),y=b.shift(),b.sort());if((!s||v.event.customEvent[y])&&!v.event.global[y])return;n=typeof n=="object"?n[v.expando]?n:new v.Event(y,n):new v.Event(y),n.type=y,n.isTrigger=!0,n.exclusive=a,n.namespace=b.join("."),n.namespace_re=n.namespace?new RegExp("(^|\\.)"+b.join("\\.(?:.*\\.|)")+"(\\.|$)"):null,h=y.indexOf(":")<0?"on"+y:"";if(!s){u=v.cache;for(f in u)u[f].events&&u[f].events[y]&&v.event.trigger(n,r,u[f].handle.elem,!0);return}n.result=t,n.target||(n.target=s),r=r!=null?v.makeArray(r):[],r.unshift(n),p=v.event.special[y]||{};if(p.trigger&&p.trigger.apply(s,r)===!1)return;m=[[s,p.bindType||y]];if(!o&&!p.noBubble&&!v.isWindow(s)){g=p.delegateType||y,l=Y.test(g+y)?s:s.parentNode;for(c=s;l;l=l.parentNode)m.push([l,g]),c=l;c===(s.ownerDocument||i)&&m.push([c.defaultView||c.parentWindow||e,g])}for(f=0;f<m.length&&!n.isPropagationStopped();f++)l=m[f][0],n.type=m[f][1],d=(v._data(l,"events")||{})[n.type]&&v._data(l,"handle"),d&&d.apply(l,r),d=h&&l[h],d&&v.acceptData(l)&&d.apply&&d.apply(l,r)===!1&&n.preventDefault();return n.type=y,!o&&!n.isDefaultPrevented()&&(!p._default||p._default.apply(s.ownerDocument,r)===!1)&&(y!=="click"||!v.nodeName(s,"a"))&&v.acceptData(s)&&h&&s[y]&&(y!=="focus"&&y!=="blur"||n.target.offsetWidth!==0)&&!v.isWindow(s)&&(c=s[h],c&&(s[h]=null),v.event.triggered=y,s[y](),v.event.triggered=t,c&&(s[h]=c)),n.result}return},dispatch:function(n){n=v.event.fix(n||e.event);var r,i,s,o,u,a,f,c,h,p,d=(v._data(this,"events")||{})[n.type]||[],m=d.delegateCount,g=l.call(arguments),y=!n.exclusive&&!n.namespace,b=v.event.special[n.type]||{},w=[];g[0]=n,n.delegateTarget=this;if(b.preDispatch&&b.preDispatch.call(this,n)===!1)return;if(m&&(!n.button||n.type!=="click"))for(s=n.target;s!=this;s=s.parentNode||this)if(s.disabled!==!0||n.type!=="click"){u={},f=[];for(r=0;r<m;r++)c=d[r],h=c.selector,u[h]===t&&(u[h]=c.needsContext?v(h,this).index(s)>=0:v.find(h,this,null,[s]).length),u[h]&&f.push(c);f.length&&w.push({elem:s,matches:f})}d.length>m&&w.push({elem:this,matches:d.slice(m)});for(r=0;r<w.length&&!n.isPropagationStopped();r++){a=w[r],n.currentTarget=a.elem;for(i=0;i<a.matches.length&&!n.isImmediatePropagationStopped();i++){c=a.matches[i];if(y||!n.namespace&&!c.namespace||n.namespace_re&&n.namespace_re.test(c.namespace))n.data=c.data,n.handleObj=c,o=((v.event.special[c.origType]||{}).handle||c.handler).apply(a.elem,g),o!==t&&(n.result=o,o===!1&&(n.preventDefault(),n.stopPropagation()))}}return b.postDispatch&&b.postDispatch.call(this,n),n.result},props:"attrChange attrName relatedNode srcElement altKey bubbles cancelable ctrlKey currentTarget eventPhase metaKey relatedTarget shiftKey target timeStamp view which".split(" "),fixHooks:{},keyHooks:{props:"char charCode key keyCode".split(" "),filter:function(e,t){return e.which==null&&(e.which=t.charCode!=null?t.charCode:t.keyCode),e}},mouseHooks:{props:"button buttons clientX clientY fromElement offsetX offsetY pageX pageY screenX screenY toElement".split(" "),filter:function(e,n){var r,s,o,u=n.button,a=n.fromElement;return e.pageX==null&&n.clientX!=null&&(r=e.target.ownerDocument||i,s=r.documentElement,o=r.body,e.pageX=n.clientX+(s&&s.scrollLeft||o&&o.scrollLeft||0)-(s&&s.clientLeft||o&&o.clientLeft||0),e.pageY=n.clientY+(s&&s.scrollTop||o&&o.scrollTop||0)-(s&&s.clientTop||o&&o.clientTop||0)),!e.relatedTarget&&a&&(e.relatedTarget=a===e.target?n.toElement:a),!e.which&&u!==t&&(e.which=u&1?1:u&2?3:u&4?2:0),e}},fix:function(e){if(e[v.expando])return e;var t,n,r=e,s=v.event.fixHooks[e.type]||{},o=s.props?this.props.concat(s.props):this.props;e=v.Event(r);for(t=o.length;t;)n=o[--t],e[n]=r[n];return e.target||(e.target=r.srcElement||i),e.target.nodeType===3&&(e.target=e.target.parentNode),e.metaKey=!!e.metaKey,s.filter?s.filter(e,r):e},special:{load:{noBubble:!0},focus:{delegateType:"focusin"},blur:{delegateType:"focusout"},beforeunload:{setup:function(e,t,n){v.isWindow(this)&&(this.onbeforeunload=n)},teardown:function(e,t){this.onbeforeunload===t&&(this.onbeforeunload=null)}}},simulate:function(e,t,n,r){var i=v.extend(new v.Event,n,{type:e,isSimulated:!0,originalEvent:{}});r?v.event.trigger(i,null,t):v.event.dispatch.call(t,i),i.isDefaultPrevented()&&n.preventDefault()}},v.event.handle=v.event.dispatch,v.removeEvent=i.removeEventListener?function(e,t,n){e.removeEventListener&&e.removeEventListener(t,n,!1)}:function(e,t,n){var r="on"+t;e.detachEvent&&(typeof e[r]=="undefined"&&(e[r]=null),e.detachEvent(r,n))},v.Event=function(e,t){if(!(this instanceof v.Event))return new v.Event(e,t);e&&e.type?(this.originalEvent=e,this.type=e.type,this.isDefaultPrevented=e.defaultPrevented||e.returnValue===!1||e.getPreventDefault&&e.getPreventDefault()?tt:et):this.type=e,t&&v.extend(this,t),this.timeStamp=e&&e.timeStamp||v.now(),this[v.expando]=!0},v.Event.prototype={preventDefault:function(){this.isDefaultPrevented=tt;var e=this.originalEvent;if(!e)return;e.preventDefault?e.preventDefault():e.returnValue=!1},stopPropagation:function(){this.isPropagationStopped=tt;var e=this.originalEvent;if(!e)return;e.stopPropagation&&e.stopPropagation(),e.cancelBubble=!0},stopImmediatePropagation:function(){this.isImmediatePropagationStopped=tt,this.stopPropagation()},isDefaultPrevented:et,isPropagationStopped:et,isImmediatePropagationStopped:et},v.each({mouseenter:"mouseover",mouseleave:"mouseout"},function(e,t){v.event.special[e]={delegateType:t,bindType:t,handle:function(e){var n,r=this,i=e.relatedTarget,s=e.handleObj,o=s.selector;if(!i||i!==r&&!v.contains(r,i))e.type=s.origType,n=s.handler.apply(this,arguments),e.type=t;return n}}}),v.support.submitBubbles||(v.event.special.submit={setup:function(){if(v.nodeName(this,"form"))return!1;v.event.add(this,"click._submit keypress._submit",function(e){var n=e.target,r=v.nodeName(n,"input")||v.nodeName(n,"button")?n.form:t;r&&!v._data(r,"_submit_attached")&&(v.event.add(r,"submit._submit",function(e){e._submit_bubble=!0}),v._data(r,"_submit_attached",!0))})},postDispatch:function(e){e._submit_bubble&&(delete e._submit_bubble,this.parentNode&&!e.isTrigger&&v.event.simulate("submit",this.parentNode,e,!0))},teardown:function(){if(v.nodeName(this,"form"))return!1;v.event.remove(this,"._submit")}}),v.support.changeBubbles||(v.event.special.change={setup:function(){if($.test(this.nodeName)){if(this.type==="checkbox"||this.type==="radio")v.event.add(this,"propertychange._change",function(e){e.originalEvent.propertyName==="checked"&&(this._just_changed=!0)}),v.event.add(this,"click._change",function(e){this._just_changed&&!e.isTrigger&&(this._just_changed=!1),v.event.simulate("change",this,e,!0)});return!1}v.event.add(this,"beforeactivate._change",function(e){var t=e.target;$.test(t.nodeName)&&!v._data(t,"_change_attached")&&(v.event.add(t,"change._change",function(e){this.parentNode&&!e.isSimulated&&!e.isTrigger&&v.event.simulate("change",this.parentNode,e,!0)}),v._data(t,"_change_attached",!0))})},handle:function(e){var t=e.target;if(this!==t||e.isSimulated||e.isTrigger||t.type!=="radio"&&t.type!=="checkbox")return e.handleObj.handler.apply(this,arguments)},teardown:function(){return v.event.remove(this,"._change"),!$.test(this.nodeName)}}),v.support.focusinBubbles||v.each({focus:"focusin",blur:"focusout"},function(e,t){var n=0,r=function(e){v.event.simulate(t,e.target,v.event.fix(e),!0)};v.event.special[t]={setup:function(){n++===0&&i.addEventListener(e,r,!0)},teardown:function(){--n===0&&i.removeEventListener(e,r,!0)}}}),v.fn.extend({on:function(e,n,r,i,s){var o,u;if(typeof e=="object"){typeof n!="string"&&(r=r||n,n=t);for(u in e)this.on(u,n,r,e[u],s);return this}r==null&&i==null?(i=n,r=n=t):i==null&&(typeof n=="string"?(i=r,r=t):(i=r,r=n,n=t));if(i===!1)i=et;else if(!i)return this;return s===1&&(o=i,i=function(e){return v().off(e),o.apply(this,arguments)},i.guid=o.guid||(o.guid=v.guid++)),this.each(function(){v.event.add(this,e,i,r,n)})},one:function(e,t,n,r){return this.on(e,t,n,r,1)},off:function(e,n,r){var i,s;if(e&&e.preventDefault&&e.handleObj)return i=e.handleObj,v(e.delegateTarget).off(i.namespace?i.origType+"."+i.namespace:i.origType,i.selector,i.handler),this;if(typeof e=="object"){for(s in e)this.off(s,n,e[s]);return this}if(n===!1||typeof n=="function")r=n,n=t;return r===!1&&(r=et),this.each(function(){v.event.remove(this,e,r,n)})},bind:function(e,t,n){return this.on(e,null,t,n)},unbind:function(e,t){return this.off(e,null,t)},live:function(e,t,n){return v(this.context).on(e,this.selector,t,n),this},die:function(e,t){return v(this.context).off(e,this.selector||"**",t),this},delegate:function(e,t,n,r){return this.on(t,e,n,r)},undelegate:function(e,t,n){return arguments.length===1?this.off(e,"**"):this.off(t,e||"**",n)},trigger:function(e,t){return this.each(function(){v.event.trigger(e,t,this)})},triggerHandler:function(e,t){if(this[0])return v.event.trigger(e,t,this[0],!0)},toggle:function(e){var t=arguments,n=e.guid||v.guid++,r=0,i=function(n){var i=(v._data(this,"lastToggle"+e.guid)||0)%r;return v._data(this,"lastToggle"+e.guid,i+1),n.preventDefault(),t[i].apply(this,arguments)||!1};i.guid=n;while(r<t.length)t[r++].guid=n;return this.click(i)},hover:function(e,t){return this.mouseenter(e).mouseleave(t||e)}}),v.each("blur focus focusin focusout load resize scroll unload click dblclick mousedown mouseup mousemove mouseover mouseout mouseenter mouseleave change select submit keydown keypress keyup error contextmenu".split(" "),function(e,t){v.fn[t]=function(e,n){return n==null&&(n=e,e=null),arguments.length>0?this.on(t,null,e,n):this.trigger(t)},Q.test(t)&&(v.event.fixHooks[t]=v.event.keyHooks),G.test(t)&&(v.event.fixHooks[t]=v.event.mouseHooks)}),function(e,t){function nt(e,t,n,r){n=n||[],t=t||g;var i,s,a,f,l=t.nodeType;if(!e||typeof e!="string")return n;if(l!==1&&l!==9)return[];a=o(t);if(!a&&!r)if(i=R.exec(e))if(f=i[1]){if(l===9){s=t.getElementById(f);if(!s||!s.parentNode)return n;if(s.id===f)return n.push(s),n}else if(t.ownerDocument&&(s=t.ownerDocument.getElementById(f))&&u(t,s)&&s.id===f)return n.push(s),n}else{if(i[2])return S.apply(n,x.call(t.getElementsByTagName(e),0)),n;if((f=i[3])&&Z&&t.getElementsByClassName)return S.apply(n,x.call(t.getElementsByClassName(f),0)),n}return vt(e.replace(j,"$1"),t,n,r,a)}function rt(e){return function(t){var n=t.nodeName.toLowerCase();return n==="input"&&t.type===e}}function it(e){return function(t){var n=t.nodeName.toLowerCase();return(n==="input"||n==="button")&&t.type===e}}function st(e){return N(function(t){return t=+t,N(function(n,r){var i,s=e([],n.length,t),o=s.length;while(o--)n[i=s[o]]&&(n[i]=!(r[i]=n[i]))})})}function ot(e,t,n){if(e===t)return n;var r=e.nextSibling;while(r){if(r===t)return-1;r=r.nextSibling}return 1}function ut(e,t){var n,r,s,o,u,a,f,l=L[d][e+" "];if(l)return t?0:l.slice(0);u=e,a=[],f=i.preFilter;while(u){if(!n||(r=F.exec(u)))r&&(u=u.slice(r[0].length)||u),a.push(s=[]);n=!1;if(r=I.exec(u))s.push(n=new m(r.shift())),u=u.slice(n.length),n.type=r[0].replace(j," ");for(o in i.filter)(r=J[o].exec(u))&&(!f[o]||(r=f[o](r)))&&(s.push(n=new m(r.shift())),u=u.slice(n.length),n.type=o,n.matches=r);if(!n)break}return t?u.length:u?nt.error(e):L(e,a).slice(0)}function at(e,t,r){var i=t.dir,s=r&&t.dir==="parentNode",o=w++;return t.first?function(t,n,r){while(t=t[i])if(s||t.nodeType===1)return e(t,n,r)}:function(t,r,u){if(!u){var a,f=b+" "+o+" ",l=f+n;while(t=t[i])if(s||t.nodeType===1){if((a=t[d])===l)return t.sizset;if(typeof a=="string"&&a.indexOf(f)===0){if(t.sizset)return t}else{t[d]=l;if(e(t,r,u))return t.sizset=!0,t;t.sizset=!1}}}else while(t=t[i])if(s||t.nodeType===1)if(e(t,r,u))return t}}function ft(e){return e.length>1?function(t,n,r){var i=e.length;while(i--)if(!e[i](t,n,r))return!1;return!0}:e[0]}function lt(e,t,n,r,i){var s,o=[],u=0,a=e.length,f=t!=null;for(;u<a;u++)if(s=e[u])if(!n||n(s,r,i))o.push(s),f&&t.push(u);return o}function ct(e,t,n,r,i,s){return r&&!r[d]&&(r=ct(r)),i&&!i[d]&&(i=ct(i,s)),N(function(s,o,u,a){var f,l,c,h=[],p=[],d=o.length,v=s||dt(t||"*",u.nodeType?[u]:u,[]),m=e&&(s||!t)?lt(v,h,e,u,a):v,g=n?i||(s?e:d||r)?[]:o:m;n&&n(m,g,u,a);if(r){f=lt(g,p),r(f,[],u,a),l=f.length;while(l--)if(c=f[l])g[p[l]]=!(m[p[l]]=c)}if(s){if(i||e){if(i){f=[],l=g.length;while(l--)(c=g[l])&&f.push(m[l]=c);i(null,g=[],f,a)}l=g.length;while(l--)(c=g[l])&&(f=i?T.call(s,c):h[l])>-1&&(s[f]=!(o[f]=c))}}else g=lt(g===o?g.splice(d,g.length):g),i?i(null,o,g,a):S.apply(o,g)})}function ht(e){var t,n,r,s=e.length,o=i.relative[e[0].type],u=o||i.relative[" "],a=o?1:0,f=at(function(e){return e===t},u,!0),l=at(function(e){return T.call(t,e)>-1},u,!0),h=[function(e,n,r){return!o&&(r||n!==c)||((t=n).nodeType?f(e,n,r):l(e,n,r))}];for(;a<s;a++)if(n=i.relative[e[a].type])h=[at(ft(h),n)];else{n=i.filter[e[a].type].apply(null,e[a].matches);if(n[d]){r=++a;for(;r<s;r++)if(i.relative[e[r].type])break;return ct(a>1&&ft(h),a>1&&e.slice(0,a-1).join("").replace(j,"$1"),n,a<r&&ht(e.slice(a,r)),r<s&&ht(e=e.slice(r)),r<s&&e.join(""))}h.push(n)}return ft(h)}function pt(e,t){var r=t.length>0,s=e.length>0,o=function(u,a,f,l,h){var p,d,v,m=[],y=0,w="0",x=u&&[],T=h!=null,N=c,C=u||s&&i.find.TAG("*",h&&a.parentNode||a),k=b+=N==null?1:Math.E;T&&(c=a!==g&&a,n=o.el);for(;(p=C[w])!=null;w++){if(s&&p){for(d=0;v=e[d];d++)if(v(p,a,f)){l.push(p);break}T&&(b=k,n=++o.el)}r&&((p=!v&&p)&&y--,u&&x.push(p))}y+=w;if(r&&w!==y){for(d=0;v=t[d];d++)v(x,m,a,f);if(u){if(y>0)while(w--)!x[w]&&!m[w]&&(m[w]=E.call(l));m=lt(m)}S.apply(l,m),T&&!u&&m.length>0&&y+t.length>1&&nt.uniqueSort(l)}return T&&(b=k,c=N),x};return o.el=0,r?N(o):o}function dt(e,t,n){var r=0,i=t.length;for(;r<i;r++)nt(e,t[r],n);return n}function vt(e,t,n,r,s){var o,u,f,l,c,h=ut(e),p=h.length;if(!r&&h.length===1){u=h[0]=h[0].slice(0);if(u.length>2&&(f=u[0]).type==="ID"&&t.nodeType===9&&!s&&i.relative[u[1].type]){t=i.find.ID(f.matches[0].replace($,""),t,s)[0];if(!t)return n;e=e.slice(u.shift().length)}for(o=J.POS.test(e)?-1:u.length-1;o>=0;o--){f=u[o];if(i.relative[l=f.type])break;if(c=i.find[l])if(r=c(f.matches[0].replace($,""),z.test(u[0].type)&&t.parentNode||t,s)){u.splice(o,1),e=r.length&&u.join("");if(!e)return S.apply(n,x.call(r,0)),n;break}}}return a(e,h)(r,t,s,n,z.test(e)),n}function mt(){}var n,r,i,s,o,u,a,f,l,c,h=!0,p="undefined",d=("sizcache"+Math.random()).replace(".",""),m=String,g=e.document,y=g.documentElement,b=0,w=0,E=[].pop,S=[].push,x=[].slice,T=[].indexOf||function(e){var t=0,n=this.length;for(;t<n;t++)if(this[t]===e)return t;return-1},N=function(e,t){return e[d]=t==null||t,e},C=function(){var e={},t=[];return N(function(n,r){return t.push(n)>i.cacheLength&&delete e[t.shift()],e[n+" "]=r},e)},k=C(),L=C(),A=C(),O="[\\x20\\t\\r\\n\\f]",M="(?:\\\\.|[-\\w]|[^\\x00-\\xa0])+",_=M.replace("w","w#"),D="([*^$|!~]?=)",P="\\["+O+"*("+M+")"+O+"*(?:"+D+O+"*(?:(['\"])((?:\\\\.|[^\\\\])*?)\\3|("+_+")|)|)"+O+"*\\]",H=":("+M+")(?:\\((?:(['\"])((?:\\\\.|[^\\\\])*?)\\2|([^()[\\]]*|(?:(?:"+P+")|[^:]|\\\\.)*|.*))\\)|)",B=":(even|odd|eq|gt|lt|nth|first|last)(?:\\("+O+"*((?:-\\d)?\\d*)"+O+"*\\)|)(?=[^-]|$)",j=new RegExp("^"+O+"+|((?:^|[^\\\\])(?:\\\\.)*)"+O+"+$","g"),F=new RegExp("^"+O+"*,"+O+"*"),I=new RegExp("^"+O+"*([\\x20\\t\\r\\n\\f>+~])"+O+"*"),q=new RegExp(H),R=/^(?:#([\w\-]+)|(\w+)|\.([\w\-]+))$/,U=/^:not/,z=/[\x20\t\r\n\f]*[+~]/,W=/:not\($/,X=/h\d/i,V=/input|select|textarea|button/i,$=/\\(?!\\)/g,J={ID:new RegExp("^#("+M+")"),CLASS:new RegExp("^\\.("+M+")"),NAME:new RegExp("^\\[name=['\"]?("+M+")['\"]?\\]"),TAG:new RegExp("^("+M.replace("w","w*")+")"),ATTR:new RegExp("^"+P),PSEUDO:new RegExp("^"+H),POS:new RegExp(B,"i"),CHILD:new RegExp("^:(only|nth|first|last)-child(?:\\("+O+"*(even|odd|(([+-]|)(\\d*)n|)"+O+"*(?:([+-]|)"+O+"*(\\d+)|))"+O+"*\\)|)","i"),needsContext:new RegExp("^"+O+"*[>+~]|"+B,"i")},K=function(e){var t=g.createElement("div");try{return e(t)}catch(n){return!1}finally{t=null}},Q=K(function(e){return e.appendChild(g.createComment("")),!e.getElementsByTagName("*").length}),G=K(function(e){return e.innerHTML="<a href='#'></a>",e.firstChild&&typeof e.firstChild.getAttribute!==p&&e.firstChild.getAttribute("href")==="#"}),Y=K(function(e){e.innerHTML="<select></select>";var t=typeof e.lastChild.getAttribute("multiple");return t!=="boolean"&&t!=="string"}),Z=K(function(e){return e.innerHTML="<div class='hidden e'></div><div class='hidden'></div>",!e.getElementsByClassName||!e.getElementsByClassName("e").length?!1:(e.lastChild.className="e",e.getElementsByClassName("e").length===2)}),et=K(function(e){e.id=d+0,e.innerHTML="<a name='"+d+"'></a><div name='"+d+"'></div>",y.insertBefore(e,y.firstChild);var t=g.getElementsByName&&g.getElementsByName(d).length===2+g.getElementsByName(d+0).length;return r=!g.getElementById(d),y.removeChild(e),t});try{x.call(y.childNodes,0)[0].nodeType}catch(tt){x=function(e){var t,n=[];for(;t=this[e];e++)n.push(t);return n}}nt.matches=function(e,t){return nt(e,null,null,t)},nt.matchesSelector=function(e,t){return nt(t,null,null,[e]).length>0},s=nt.getText=function(e){var t,n="",r=0,i=e.nodeType;if(i){if(i===1||i===9||i===11){if(typeof e.textContent=="string")return e.textContent;for(e=e.firstChild;e;e=e.nextSibling)n+=s(e)}else if(i===3||i===4)return e.nodeValue}else for(;t=e[r];r++)n+=s(t);return n},o=nt.isXML=function(e){var t=e&&(e.ownerDocument||e).documentElement;return t?t.nodeName!=="HTML":!1},u=nt.contains=y.contains?function(e,t){var n=e.nodeType===9?e.documentElement:e,r=t&&t.parentNode;return e===r||!!(r&&r.nodeType===1&&n.contains&&n.contains(r))}:y.compareDocumentPosition?function(e,t){return t&&!!(e.compareDocumentPosition(t)&16)}:function(e,t){while(t=t.parentNode)if(t===e)return!0;return!1},nt.attr=function(e,t){var n,r=o(e);return r||(t=t.toLowerCase()),(n=i.attrHandle[t])?n(e):r||Y?e.getAttribute(t):(n=e.getAttributeNode(t),n?typeof e[t]=="boolean"?e[t]?t:null:n.specified?n.value:null:null)},i=nt.selectors={cacheLength:50,createPseudo:N,match:J,attrHandle:G?{}:{href:function(e){return e.getAttribute("href",2)},type:function(e){return e.getAttribute("type")}},find:{ID:r?function(e,t,n){if(typeof t.getElementById!==p&&!n){var r=t.getElementById(e);return r&&r.parentNode?[r]:[]}}:function(e,n,r){if(typeof n.getElementById!==p&&!r){var i=n.getElementById(e);return i?i.id===e||typeof i.getAttributeNode!==p&&i.getAttributeNode("id").value===e?[i]:t:[]}},TAG:Q?function(e,t){if(typeof t.getElementsByTagName!==p)return t.getElementsByTagName(e)}:function(e,t){var n=t.getElementsByTagName(e);if(e==="*"){var r,i=[],s=0;for(;r=n[s];s++)r.nodeType===1&&i.push(r);return i}return n},NAME:et&&function(e,t){if(typeof t.getElementsByName!==p)return t.getElementsByName(name)},CLASS:Z&&function(e,t,n){if(typeof t.getElementsByClassName!==p&&!n)return t.getElementsByClassName(e)}},relative:{">":{dir:"parentNode",first:!0}," ":{dir:"parentNode"},"+":{dir:"previousSibling",first:!0},"~":{dir:"previousSibling"}},preFilter:{ATTR:function(e){return e[1]=e[1].replace($,""),e[3]=(e[4]||e[5]||"").replace($,""),e[2]==="~="&&(e[3]=" "+e[3]+" "),e.slice(0,4)},CHILD:function(e){return e[1]=e[1].toLowerCase(),e[1]==="nth"?(e[2]||nt.error(e[0]),e[3]=+(e[3]?e[4]+(e[5]||1):2*(e[2]==="even"||e[2]==="odd")),e[4]=+(e[6]+e[7]||e[2]==="odd")):e[2]&&nt.error(e[0]),e},PSEUDO:function(e){var t,n;if(J.CHILD.test(e[0]))return null;if(e[3])e[2]=e[3];else if(t=e[4])q.test(t)&&(n=ut(t,!0))&&(n=t.indexOf(")",t.length-n)-t.length)&&(t=t.slice(0,n),e[0]=e[0].slice(0,n)),e[2]=t;return e.slice(0,3)}},filter:{ID:r?function(e){return e=e.replace($,""),function(t){return t.getAttribute("id")===e}}:function(e){return e=e.replace($,""),function(t){var n=typeof t.getAttributeNode!==p&&t.getAttributeNode("id");return n&&n.value===e}},TAG:function(e){return e==="*"?function(){return!0}:(e=e.replace($,"").toLowerCase(),function(t){return t.nodeName&&t.nodeName.toLowerCase()===e})},CLASS:function(e){var t=k[d][e+" "];return t||(t=new RegExp("(^|"+O+")"+e+"("+O+"|$)"))&&k(e,function(e){return t.test(e.className||typeof e.getAttribute!==p&&e.getAttribute("class")||"")})},ATTR:function(e,t,n){return function(r,i){var s=nt.attr(r,e);return s==null?t==="!=":t?(s+="",t==="="?s===n:t==="!="?s!==n:t==="^="?n&&s.indexOf(n)===0:t==="*="?n&&s.indexOf(n)>-1:t==="$="?n&&s.substr(s.length-n.length)===n:t==="~="?(" "+s+" ").indexOf(n)>-1:t==="|="?s===n||s.substr(0,n.length+1)===n+"-":!1):!0}},CHILD:function(e,t,n,r){return e==="nth"?function(e){var t,i,s=e.parentNode;if(n===1&&r===0)return!0;if(s){i=0;for(t=s.firstChild;t;t=t.nextSibling)if(t.nodeType===1){i++;if(e===t)break}}return i-=r,i===n||i%n===0&&i/n>=0}:function(t){var n=t;switch(e){case"only":case"first":while(n=n.previousSibling)if(n.nodeType===1)return!1;if(e==="first")return!0;n=t;case"last":while(n=n.nextSibling)if(n.nodeType===1)return!1;return!0}}},PSEUDO:function(e,t){var n,r=i.pseudos[e]||i.setFilters[e.toLowerCase()]||nt.error("unsupported pseudo: "+e);return r[d]?r(t):r.length>1?(n=[e,e,"",t],i.setFilters.hasOwnProperty(e.toLowerCase())?N(function(e,n){var i,s=r(e,t),o=s.length;while(o--)i=T.call(e,s[o]),e[i]=!(n[i]=s[o])}):function(e){return r(e,0,n)}):r}},pseudos:{not:N(function(e){var t=[],n=[],r=a(e.replace(j,"$1"));return r[d]?N(function(e,t,n,i){var s,o=r(e,null,i,[]),u=e.length;while(u--)if(s=o[u])e[u]=!(t[u]=s)}):function(e,i,s){return t[0]=e,r(t,null,s,n),!n.pop()}}),has:N(function(e){return function(t){return nt(e,t).length>0}}),contains:N(function(e){return function(t){return(t.textContent||t.innerText||s(t)).indexOf(e)>-1}}),enabled:function(e){return e.disabled===!1},disabled:function(e){return e.disabled===!0},checked:function(e){var t=e.nodeName.toLowerCase();return t==="input"&&!!e.checked||t==="option"&&!!e.selected},selected:function(e){return e.parentNode&&e.parentNode.selectedIndex,e.selected===!0},parent:function(e){return!i.pseudos.empty(e)},empty:function(e){var t;e=e.firstChild;while(e){if(e.nodeName>"@"||(t=e.nodeType)===3||t===4)return!1;e=e.nextSibling}return!0},header:function(e){return X.test(e.nodeName)},text:function(e){var t,n;return e.nodeName.toLowerCase()==="input"&&(t=e.type)==="text"&&((n=e.getAttribute("type"))==null||n.toLowerCase()===t)},radio:rt("radio"),checkbox:rt("checkbox"),file:rt("file"),password:rt("password"),image:rt("image"),submit:it("submit"),reset:it("reset"),button:function(e){var t=e.nodeName.toLowerCase();return t==="input"&&e.type==="button"||t==="button"},input:function(e){return V.test(e.nodeName)},focus:function(e){var t=e.ownerDocument;return e===t.activeElement&&(!t.hasFocus||t.hasFocus())&&!!(e.type||e.href||~e.tabIndex)},active:function(e){return e===e.ownerDocument.activeElement},first:st(function(){return[0]}),last:st(function(e,t){return[t-1]}),eq:st(function(e,t,n){return[n<0?n+t:n]}),even:st(function(e,t){for(var n=0;n<t;n+=2)e.push(n);return e}),odd:st(function(e,t){for(var n=1;n<t;n+=2)e.push(n);return e}),lt:st(function(e,t,n){for(var r=n<0?n+t:n;--r>=0;)e.push(r);return e}),gt:st(function(e,t,n){for(var r=n<0?n+t:n;++r<t;)e.push(r);return e})}},f=y.compareDocumentPosition?function(e,t){return e===t?(l=!0,0):(!e.compareDocumentPosition||!t.compareDocumentPosition?e.compareDocumentPosition:e.compareDocumentPosition(t)&4)?-1:1}:function(e,t){if(e===t)return l=!0,0;if(e.sourceIndex&&t.sourceIndex)return e.sourceIndex-t.sourceIndex;var n,r,i=[],s=[],o=e.parentNode,u=t.parentNode,a=o;if(o===u)return ot(e,t);if(!o)return-1;if(!u)return 1;while(a)i.unshift(a),a=a.parentNode;a=u;while(a)s.unshift(a),a=a.parentNode;n=i.length,r=s.length;for(var f=0;f<n&&f<r;f++)if(i[f]!==s[f])return ot(i[f],s[f]);return f===n?ot(e,s[f],-1):ot(i[f],t,1)},[0,0].sort(f),h=!l,nt.uniqueSort=function(e){var t,n=[],r=1,i=0;l=h,e.sort(f);if(l){for(;t=e[r];r++)t===e[r-1]&&(i=n.push(r));while(i--)e.splice(n[i],1)}return e},nt.error=function(e){throw new Error("Syntax error, unrecognized expression: "+e)},a=nt.compile=function(e,t){var n,r=[],i=[],s=A[d][e+" "];if(!s){t||(t=ut(e)),n=t.length;while(n--)s=ht(t[n]),s[d]?r.push(s):i.push(s);s=A(e,pt(i,r))}return s},g.querySelectorAll&&function(){var e,t=vt,n=/'|\\/g,r=/\=[\x20\t\r\n\f]*([^'"\]]*)[\x20\t\r\n\f]*\]/g,i=[":focus"],s=[":active"],u=y.matchesSelector||y.mozMatchesSelector||y.webkitMatchesSelector||y.oMatchesSelector||y.msMatchesSelector;K(function(e){e.innerHTML="<select><option selected=''></option></select>",e.querySelectorAll("[selected]").length||i.push("\\["+O+"*(?:checked|disabled|ismap|multiple|readonly|selected|value)"),e.querySelectorAll(":checked").length||i.push(":checked")}),K(function(e){e.innerHTML="<p test=''></p>",e.querySelectorAll("[test^='']").length&&i.push("[*^$]="+O+"*(?:\"\"|'')"),e.innerHTML="<input type='hidden'/>",e.querySelectorAll(":enabled").length||i.push(":enabled",":disabled")}),i=new RegExp(i.join("|")),vt=function(e,r,s,o,u){if(!o&&!u&&!i.test(e)){var a,f,l=!0,c=d,h=r,p=r.nodeType===9&&e;if(r.nodeType===1&&r.nodeName.toLowerCase()!=="object"){a=ut(e),(l=r.getAttribute("id"))?c=l.replace(n,"\\$&"):r.setAttribute("id",c),c="[id='"+c+"'] ",f=a.length;while(f--)a[f]=c+a[f].join("");h=z.test(e)&&r.parentNode||r,p=a.join(",")}if(p)try{return S.apply(s,x.call(h.querySelectorAll(p),0)),s}catch(v){}finally{l||r.removeAttribute("id")}}return t(e,r,s,o,u)},u&&(K(function(t){e=u.call(t,"div");try{u.call(t,"[test!='']:sizzle"),s.push("!=",H)}catch(n){}}),s=new RegExp(s.join("|")),nt.matchesSelector=function(t,n){n=n.replace(r,"='$1']");if(!o(t)&&!s.test(n)&&!i.test(n))try{var a=u.call(t,n);if(a||e||t.document&&t.document.nodeType!==11)return a}catch(f){}return nt(n,null,null,[t]).length>0})}(),i.pseudos.nth=i.pseudos.eq,i.filters=mt.prototype=i.pseudos,i.setFilters=new mt,nt.attr=v.attr,v.find=nt,v.expr=nt.selectors,v.expr[":"]=v.expr.pseudos,v.unique=nt.uniqueSort,v.text=nt.getText,v.isXMLDoc=nt.isXML,v.contains=nt.contains}(e);var nt=/Until$/,rt=/^(?:parents|prev(?:Until|All))/,it=/^.[^:#\[\.,]*$/,st=v.expr.match.needsContext,ot={children:!0,contents:!0,next:!0,prev:!0};v.fn.extend({find:function(e){var t,n,r,i,s,o,u=this;if(typeof e!="string")return v(e).filter(function(){for(t=0,n=u.length;t<n;t++)if(v.contains(u[t],this))return!0});o=this.pushStack("","find",e);for(t=0,n=this.length;t<n;t++){r=o.length,v.find(e,this[t],o);if(t>0)for(i=r;i<o.length;i++)for(s=0;s<r;s++)if(o[s]===o[i]){o.splice(i--,1);break}}return o},has:function(e){var t,n=v(e,this),r=n.length;return this.filter(function(){for(t=0;t<r;t++)if(v.contains(this,n[t]))return!0})},not:function(e){return this.pushStack(ft(this,e,!1),"not",e)},filter:function(e){return this.pushStack(ft(this,e,!0),"filter",e)},is:function(e){return!!e&&(typeof e=="string"?st.test(e)?v(e,this.context).index(this[0])>=0:v.filter(e,this).length>0:this.filter(e).length>0)},closest:function(e,t){var n,r=0,i=this.length,s=[],o=st.test(e)||typeof e!="string"?v(e,t||this.context):0;for(;r<i;r++){n=this[r];while(n&&n.ownerDocument&&n!==t&&n.nodeType!==11){if(o?o.index(n)>-1:v.find.matchesSelector(n,e)){s.push(n);break}n=n.parentNode}}return s=s.length>1?v.unique(s):s,this.pushStack(s,"closest",e)},index:function(e){return e?typeof e=="string"?v.inArray(this[0],v(e)):v.inArray(e.jquery?e[0]:e,this):this[0]&&this[0].parentNode?this.prevAll().length:-1},add:function(e,t){var n=typeof e=="string"?v(e,t):v.makeArray(e&&e.nodeType?[e]:e),r=v.merge(this.get(),n);return this.pushStack(ut(n[0])||ut(r[0])?r:v.unique(r))},addBack:function(e){return this.add(e==null?this.prevObject:this.prevObject.filter(e))}}),v.fn.andSelf=v.fn.addBack,v.each({parent:function(e){var t=e.parentNode;return t&&t.nodeType!==11?t:null},parents:function(e){return v.dir(e,"parentNode")},parentsUntil:function(e,t,n){return v.dir(e,"parentNode",n)},next:function(e){return at(e,"nextSibling")},prev:function(e){return at(e,"previousSibling")},nextAll:function(e){return v.dir(e,"nextSibling")},prevAll:function(e){return v.dir(e,"previousSibling")},nextUntil:function(e,t,n){return v.dir(e,"nextSibling",n)},prevUntil:function(e,t,n){return v.dir(e,"previousSibling",n)},siblings:function(e){return v.sibling((e.parentNode||{}).firstChild,e)},children:function(e){return v.sibling(e.firstChild)},contents:function(e){return v.nodeName(e,"iframe")?e.contentDocument||e.contentWindow.document:v.merge([],e.childNodes)}},function(e,t){v.fn[e]=function(n,r){var i=v.map(this,t,n);return nt.test(e)||(r=n),r&&typeof r=="string"&&(i=v.filter(r,i)),i=this.length>1&&!ot[e]?v.unique(i):i,this.length>1&&rt.test(e)&&(i=i.reverse()),this.pushStack(i,e,l.call(arguments).join(","))}}),v.extend({filter:function(e,t,n){return n&&(e=":not("+e+")"),t.length===1?v.find.matchesSelector(t[0],e)?[t[0]]:[]:v.find.matches(e,t)},dir:function(e,n,r){var i=[],s=e[n];while(s&&s.nodeType!==9&&(r===t||s.nodeType!==1||!v(s).is(r)))s.nodeType===1&&i.push(s),s=s[n];return i},sibling:function(e,t){var n=[];for(;e;e=e.nextSibling)e.nodeType===1&&e!==t&&n.push(e);return n}});var ct="abbr|article|aside|audio|bdi|canvas|data|datalist|details|figcaption|figure|footer|header|hgroup|mark|meter|nav|output|progress|section|summary|time|video",ht=/ jQuery\d+="(?:null|\d+)"/g,pt=/^\s+/,dt=/<(?!area|br|col|embed|hr|img|input|link|meta|param)(([\w:]+)[^>]*)\/>/gi,vt=/<([\w:]+)/,mt=/<tbody/i,gt=/<|&#?\w+;/,yt=/<(?:script|style|link)/i,bt=/<(?:script|object|embed|option|style)/i,wt=new RegExp("<(?:"+ct+")[\\s/>]","i"),Et=/^(?:checkbox|radio)$/,St=/checked\s*(?:[^=]|=\s*.checked.)/i,xt=/\/(java|ecma)script/i,Tt=/^\s*<!(?:\[CDATA\[|\-\-)|[\]\-]{2}>\s*$/g,Nt={option:[1,"<select multiple='multiple'>","</select>"],legend:[1,"<fieldset>","</fieldset>"],thead:[1,"<table>","</table>"],tr:[2,"<table><tbody>","</tbody></table>"],td:[3,"<table><tbody><tr>","</tr></tbody></table>"],col:[2,"<table><tbody></tbody><colgroup>","</colgroup></table>"],area:[1,"<map>","</map>"],_default:[0,"",""]},Ct=lt(i),kt=Ct.appendChild(i.createElement("div"));Nt.optgroup=Nt.option,Nt.tbody=Nt.tfoot=Nt.colgroup=Nt.caption=Nt.thead,Nt.th=Nt.td,v.support.htmlSerialize||(Nt._default=[1,"X<div>","</div>"]),v.fn.extend({text:function(e){return v.access(this,function(e){return e===t?v.text(this):this.empty().append((this[0]&&this[0].ownerDocument||i).createTextNode(e))},null,e,arguments.length)},wrapAll:function(e){if(v.isFunction(e))return this.each(function(t){v(this).wrapAll(e.call(this,t))});if(this[0]){var t=v(e,this[0].ownerDocument).eq(0).clone(!0);this[0].parentNode&&t.insertBefore(this[0]),t.map(function(){var e=this;while(e.firstChild&&e.firstChild.nodeType===1)e=e.firstChild;return e}).append(this)}return this},wrapInner:function(e){return v.isFunction(e)?this.each(function(t){v(this).wrapInner(e.call(this,t))}):this.each(function(){var t=v(this),n=t.contents();n.length?n.wrapAll(e):t.append(e)})},wrap:function(e){var t=v.isFunction(e);return this.each(function(n){v(this).wrapAll(t?e.call(this,n):e)})},unwrap:function(){return this.parent().each(function(){v.nodeName(this,"body")||v(this).replaceWith(this.childNodes)}).end()},append:function(){return this.domManip(arguments,!0,function(e){(this.nodeType===1||this.nodeType===11)&&this.appendChild(e)})},prepend:function(){return this.domManip(arguments,!0,function(e){(this.nodeType===1||this.nodeType===11)&&this.insertBefore(e,this.firstChild)})},before:function(){if(!ut(this[0]))return this.domManip(arguments,!1,function(e){this.parentNode.insertBefore(e,this)});if(arguments.length){var e=v.clean(arguments);return this.pushStack(v.merge(e,this),"before",this.selector)}},after:function(){if(!ut(this[0]))return this.domManip(arguments,!1,function(e){this.parentNode.insertBefore(e,this.nextSibling)});if(arguments.length){var e=v.clean(arguments);return this.pushStack(v.merge(this,e),"after",this.selector)}},remove:function(e,t){var n,r=0;for(;(n=this[r])!=null;r++)if(!e||v.filter(e,[n]).length)!t&&n.nodeType===1&&(v.cleanData(n.getElementsByTagName("*")),v.cleanData([n])),n.parentNode&&n.parentNode.removeChild(n);return this},empty:function(){var e,t=0;for(;(e=this[t])!=null;t++){e.nodeType===1&&v.cleanData(e.getElementsByTagName("*"));while(e.firstChild)e.removeChild(e.firstChild)}return this},clone:function(e,t){return e=e==null?!1:e,t=t==null?e:t,this.map(function(){return v.clone(this,e,t)})},html:function(e){return v.access(this,function(e){var n=this[0]||{},r=0,i=this.length;if(e===t)return n.nodeType===1?n.innerHTML.replace(ht,""):t;if(typeof e=="string"&&!yt.test(e)&&(v.support.htmlSerialize||!wt.test(e))&&(v.support.leadingWhitespace||!pt.test(e))&&!Nt[(vt.exec(e)||["",""])[1].toLowerCase()]){e=e.replace(dt,"<$1></$2>");try{for(;r<i;r++)n=this[r]||{},n.nodeType===1&&(v.cleanData(n.getElementsByTagName("*")),n.innerHTML=e);n=0}catch(s){}}n&&this.empty().append(e)},null,e,arguments.length)},replaceWith:function(e){return ut(this[0])?this.length?this.pushStack(v(v.isFunction(e)?e():e),"replaceWith",e):this:v.isFunction(e)?this.each(function(t){var n=v(this),r=n.html();n.replaceWith(e.call(this,t,r))}):(typeof e!="string"&&(e=v(e).detach()),this.each(function(){var t=this.nextSibling,n=this.parentNode;v(this).remove(),t?v(t).before(e):v(n).append(e)}))},detach:function(e){return this.remove(e,!0)},domManip:function(e,n,r){e=[].concat.apply([],e);var i,s,o,u,a=0,f=e[0],l=[],c=this.length;if(!v.support.checkClone&&c>1&&typeof f=="string"&&St.test(f))return this.each(function(){v(this).domManip(e,n,r)});if(v.isFunction(f))return this.each(function(i){var s=v(this);e[0]=f.call(this,i,n?s.html():t),s.domManip(e,n,r)});if(this[0]){i=v.buildFragment(e,this,l),o=i.fragment,s=o.firstChild,o.childNodes.length===1&&(o=s);if(s){n=n&&v.nodeName(s,"tr");for(u=i.cacheable||c-1;a<c;a++)r.call(n&&v.nodeName(this[a],"table")?Lt(this[a],"tbody"):this[a],a===u?o:v.clone(o,!0,!0))}o=s=null,l.length&&v.each(l,function(e,t){t.src?v.ajax?v.ajax({url:t.src,type:"GET",dataType:"script",async:!1,global:!1,"throws":!0}):v.error("no ajax"):v.globalEval((t.text||t.textContent||t.innerHTML||"").replace(Tt,"")),t.parentNode&&t.parentNode.removeChild(t)})}return this}}),v.buildFragment=function(e,n,r){var s,o,u,a=e[0];return n=n||i,n=!n.nodeType&&n[0]||n,n=n.ownerDocument||n,e.length===1&&typeof a=="string"&&a.length<512&&n===i&&a.charAt(0)==="<"&&!bt.test(a)&&(v.support.checkClone||!St.test(a))&&(v.support.html5Clone||!wt.test(a))&&(o=!0,s=v.fragments[a],u=s!==t),s||(s=n.createDocumentFragment(),v.clean(e,n,s,r),o&&(v.fragments[a]=u&&s)),{fragment:s,cacheable:o}},v.fragments={},v.each({appendTo:"append",prependTo:"prepend",insertBefore:"before",insertAfter:"after",replaceAll:"replaceWith"},function(e,t){v.fn[e]=function(n){var r,i=0,s=[],o=v(n),u=o.length,a=this.length===1&&this[0].parentNode;if((a==null||a&&a.nodeType===11&&a.childNodes.length===1)&&u===1)return o[t](this[0]),this;for(;i<u;i++)r=(i>0?this.clone(!0):this).get(),v(o[i])[t](r),s=s.concat(r);return this.pushStack(s,e,o.selector)}}),v.extend({clone:function(e,t,n){var r,i,s,o;v.support.html5Clone||v.isXMLDoc(e)||!wt.test("<"+e.nodeName+">")?o=e.cloneNode(!0):(kt.innerHTML=e.outerHTML,kt.removeChild(o=kt.firstChild));if((!v.support.noCloneEvent||!v.support.noCloneChecked)&&(e.nodeType===1||e.nodeType===11)&&!v.isXMLDoc(e)){Ot(e,o),r=Mt(e),i=Mt(o);for(s=0;r[s];++s)i[s]&&Ot(r[s],i[s])}if(t){At(e,o);if(n){r=Mt(e),i=Mt(o);for(s=0;r[s];++s)At(r[s],i[s])}}return r=i=null,o},clean:function(e,t,n,r){var s,o,u,a,f,l,c,h,p,d,m,g,y=t===i&&Ct,b=[];if(!t||typeof t.createDocumentFragment=="undefined")t=i;for(s=0;(u=e[s])!=null;s++){typeof u=="number"&&(u+="");if(!u)continue;if(typeof u=="string")if(!gt.test(u))u=t.createTextNode(u);else{y=y||lt(t),c=t.createElement("div"),y.appendChild(c),u=u.replace(dt,"<$1></$2>"),a=(vt.exec(u)||["",""])[1].toLowerCase(),f=Nt[a]||Nt._default,l=f[0],c.innerHTML=f[1]+u+f[2];while(l--)c=c.lastChild;if(!v.support.tbody){h=mt.test(u),p=a==="table"&&!h?c.firstChild&&c.firstChild.childNodes:f[1]==="<table>"&&!h?c.childNodes:[];for(o=p.length-1;o>=0;--o)v.nodeName(p[o],"tbody")&&!p[o].childNodes.length&&p[o].parentNode.removeChild(p[o])}!v.support.leadingWhitespace&&pt.test(u)&&c.insertBefore(t.createTextNode(pt.exec(u)[0]),c.firstChild),u=c.childNodes,c.parentNode.removeChild(c)}u.nodeType?b.push(u):v.merge(b,u)}c&&(u=c=y=null);if(!v.support.appendChecked)for(s=0;(u=b[s])!=null;s++)v.nodeName(u,"input")?_t(u):typeof u.getElementsByTagName!="undefined"&&v.grep(u.getElementsByTagName("input"),_t);if(n){m=function(e){if(!e.type||xt.test(e.type))return r?r.push(e.parentNode?e.parentNode.removeChild(e):e):n.appendChild(e)};for(s=0;(u=b[s])!=null;s++)if(!v.nodeName(u,"script")||!m(u))n.appendChild(u),typeof u.getElementsByTagName!="undefined"&&(g=v.grep(v.merge([],u.getElementsByTagName("script")),m),b.splice.apply(b,[s+1,0].concat(g)),s+=g.length)}return b},cleanData:function(e,t){var n,r,i,s,o=0,u=v.expando,a=v.cache,f=v.support.deleteExpando,l=v.event.special;for(;(i=e[o])!=null;o++)if(t||v.acceptData(i)){r=i[u],n=r&&a[r];if(n){if(n.events)for(s in n.events)l[s]?v.event.remove(i,s):v.removeEvent(i,s,n.handle);a[r]&&(delete a[r],f?delete i[u]:i.removeAttribute?i.removeAttribute(u):i[u]=null,v.deletedIds.push(r))}}}}),function(){var e,t;v.uaMatch=function(e){e=e.toLowerCase();var t=/(chrome)[ \/]([\w.]+)/.exec(e)||/(webkit)[ \/]([\w.]+)/.exec(e)||/(opera)(?:.*version|)[ \/]([\w.]+)/.exec(e)||/(msie) ([\w.]+)/.exec(e)||e.indexOf("compatible")<0&&/(mozilla)(?:.*? rv:([\w.]+)|)/.exec(e)||[];return{browser:t[1]||"",version:t[2]||"0"}},e=v.uaMatch(o.userAgent),t={},e.browser&&(t[e.browser]=!0,t.version=e.version),t.chrome?t.webkit=!0:t.webkit&&(t.safari=!0),v.browser=t,v.sub=function(){function e(t,n){return new e.fn.init(t,n)}v.extend(!0,e,this),e.superclass=this,e.fn=e.prototype=this(),e.fn.constructor=e,e.sub=this.sub,e.fn.init=function(r,i){return i&&i instanceof v&&!(i instanceof e)&&(i=e(i)),v.fn.init.call(this,r,i,t)},e.fn.init.prototype=e.fn;var t=e(i);return e}}();var Dt,Pt,Ht,Bt=/alpha\([^)]*\)/i,jt=/opacity=([^)]*)/,Ft=/^(top|right|bottom|left)$/,It=/^(none|table(?!-c[ea]).+)/,qt=/^margin/,Rt=new RegExp("^("+m+")(.*)$","i"),Ut=new RegExp("^("+m+")(?!px)[a-z%]+$","i"),zt=new RegExp("^([-+])=("+m+")","i"),Wt={BODY:"block"},Xt={position:"absolute",visibility:"hidden",display:"block"},Vt={letterSpacing:0,fontWeight:400},$t=["Top","Right","Bottom","Left"],Jt=["Webkit","O","Moz","ms"],Kt=v.fn.toggle;v.fn.extend({css:function(e,n){return v.access(this,function(e,n,r){return r!==t?v.style(e,n,r):v.css(e,n)},e,n,arguments.length>1)},show:function(){return Yt(this,!0)},hide:function(){return Yt(this)},toggle:function(e,t){var n=typeof e=="boolean";return v.isFunction(e)&&v.isFunction(t)?Kt.apply(this,arguments):this.each(function(){(n?e:Gt(this))?v(this).show():v(this).hide()})}}),v.extend({cssHooks:{opacity:{get:function(e,t){if(t){var n=Dt(e,"opacity");return n===""?"1":n}}}},cssNumber:{fillOpacity:!0,fontWeight:!0,lineHeight:!0,opacity:!0,orphans:!0,widows:!0,zIndex:!0,zoom:!0},cssProps:{"float":v.support.cssFloat?"cssFloat":"styleFloat"},style:function(e,n,r,i){if(!e||e.nodeType===3||e.nodeType===8||!e.style)return;var s,o,u,a=v.camelCase(n),f=e.style;n=v.cssProps[a]||(v.cssProps[a]=Qt(f,a)),u=v.cssHooks[n]||v.cssHooks[a];if(r===t)return u&&"get"in u&&(s=u.get(e,!1,i))!==t?s:f[n];o=typeof r,o==="string"&&(s=zt.exec(r))&&(r=(s[1]+1)*s[2]+parseFloat(v.css(e,n)),o="number");if(r==null||o==="number"&&isNaN(r))return;o==="number"&&!v.cssNumber[a]&&(r+="px");if(!u||!("set"in u)||(r=u.set(e,r,i))!==t)try{f[n]=r}catch(l){}},css:function(e,n,r,i){var s,o,u,a=v.camelCase(n);return n=v.cssProps[a]||(v.cssProps[a]=Qt(e.style,a)),u=v.cssHooks[n]||v.cssHooks[a],u&&"get"in u&&(s=u.get(e,!0,i)),s===t&&(s=Dt(e,n)),s==="normal"&&n in Vt&&(s=Vt[n]),r||i!==t?(o=parseFloat(s),r||v.isNumeric(o)?o||0:s):s},swap:function(e,t,n){var r,i,s={};for(i in t)s[i]=e.style[i],e.style[i]=t[i];r=n.call(e);for(i in t)e.style[i]=s[i];return r}}),e.getComputedStyle?Dt=function(t,n){var r,i,s,o,u=e.getComputedStyle(t,null),a=t.style;return u&&(r=u.getPropertyValue(n)||u[n],r===""&&!v.contains(t.ownerDocument,t)&&(r=v.style(t,n)),Ut.test(r)&&qt.test(n)&&(i=a.width,s=a.minWidth,o=a.maxWidth,a.minWidth=a.maxWidth=a.width=r,r=u.width,a.width=i,a.minWidth=s,a.maxWidth=o)),r}:i.documentElement.currentStyle&&(Dt=function(e,t){var n,r,i=e.currentStyle&&e.currentStyle[t],s=e.style;return i==null&&s&&s[t]&&(i=s[t]),Ut.test(i)&&!Ft.test(t)&&(n=s.left,r=e.runtimeStyle&&e.runtimeStyle.left,r&&(e.runtimeStyle.left=e.currentStyle.left),s.left=t==="fontSize"?"1em":i,i=s.pixelLeft+"px",s.left=n,r&&(e.runtimeStyle.left=r)),i===""?"auto":i}),v.each(["height","width"],function(e,t){v.cssHooks[t]={get:function(e,n,r){if(n)return e.offsetWidth===0&&It.test(Dt(e,"display"))?v.swap(e,Xt,function(){return tn(e,t,r)}):tn(e,t,r)},set:function(e,n,r){return Zt(e,n,r?en(e,t,r,v.support.boxSizing&&v.css(e,"boxSizing")==="border-box"):0)}}}),v.support.opacity||(v.cssHooks.opacity={get:function(e,t){return jt.test((t&&e.currentStyle?e.currentStyle.filter:e.style.filter)||"")?.01*parseFloat(RegExp.$1)+"":t?"1":""},set:function(e,t){var n=e.style,r=e.currentStyle,i=v.isNumeric(t)?"alpha(opacity="+t*100+")":"",s=r&&r.filter||n.filter||"";n.zoom=1;if(t>=1&&v.trim(s.replace(Bt,""))===""&&n.removeAttribute){n.removeAttribute("filter");if(r&&!r.filter)return}n.filter=Bt.test(s)?s.replace(Bt,i):s+" "+i}}),v(function(){v.support.reliableMarginRight||(v.cssHooks.marginRight={get:function(e,t){return v.swap(e,{display:"inline-block"},function(){if(t)return Dt(e,"marginRight")})}}),!v.support.pixelPosition&&v.fn.position&&v.each(["top","left"],function(e,t){v.cssHooks[t]={get:function(e,n){if(n){var r=Dt(e,t);return Ut.test(r)?v(e).position()[t]+"px":r}}}})}),v.expr&&v.expr.filters&&(v.expr.filters.hidden=function(e){return e.offsetWidth===0&&e.offsetHeight===0||!v.support.reliableHiddenOffsets&&(e.style&&e.style.display||Dt(e,"display"))==="none"},v.expr.filters.visible=function(e){return!v.expr.filters.hidden(e)}),v.each({margin:"",padding:"",border:"Width"},function(e,t){v.cssHooks[e+t]={expand:function(n){var r,i=typeof n=="string"?n.split(" "):[n],s={};for(r=0;r<4;r++)s[e+$t[r]+t]=i[r]||i[r-2]||i[0];return s}},qt.test(e)||(v.cssHooks[e+t].set=Zt)});var rn=/%20/g,sn=/\[\]$/,on=/\r?\n/g,un=/^(?:color|date|datetime|datetime-local|email|hidden|month|number|password|range|search|tel|text|time|url|week)$/i,an=/^(?:select|textarea)/i;v.fn.extend({serialize:function(){return v.param(this.serializeArray())},serializeArray:function(){return this.map(function(){return this.elements?v.makeArray(this.elements):this}).filter(function(){return this.name&&!this.disabled&&(this.checked||an.test(this.nodeName)||un.test(this.type))}).map(function(e,t){var n=v(this).val();return n==null?null:v.isArray(n)?v.map(n,function(e,n){return{name:t.name,value:e.replace(on,"\r\n")}}):{name:t.name,value:n.replace(on,"\r\n")}}).get()}}),v.param=function(e,n){var r,i=[],s=function(e,t){t=v.isFunction(t)?t():t==null?"":t,i[i.length]=encodeURIComponent(e)+"="+encodeURIComponent(t)};n===t&&(n=v.ajaxSettings&&v.ajaxSettings.traditional);if(v.isArray(e)||e.jquery&&!v.isPlainObject(e))v.each(e,function(){s(this.name,this.value)});else for(r in e)fn(r,e[r],n,s);return i.join("&").replace(rn,"+")};var ln,cn,hn=/#.*$/,pn=/^(.*?):[ \t]*([^\r\n]*)\r?$/mg,dn=/^(?:about|app|app\-storage|.+\-extension|file|res|widget):$/,vn=/^(?:GET|HEAD)$/,mn=/^\/\//,gn=/\?/,yn=/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi,bn=/([?&])_=[^&]*/,wn=/^([\w\+\.\-]+:)(?:\/\/([^\/?#:]*)(?::(\d+)|)|)/,En=v.fn.load,Sn={},xn={},Tn=["*/"]+["*"];try{cn=s.href}catch(Nn){cn=i.createElement("a"),cn.href="",cn=cn.href}ln=wn.exec(cn.toLowerCase())||[],v.fn.load=function(e,n,r){if(typeof e!="string"&&En)return En.apply(this,arguments);if(!this.length)return this;var i,s,o,u=this,a=e.indexOf(" ");return a>=0&&(i=e.slice(a,e.length),e=e.slice(0,a)),v.isFunction(n)?(r=n,n=t):n&&typeof n=="object"&&(s="POST"),v.ajax({url:e,type:s,dataType:"html",data:n,complete:function(e,t){r&&u.each(r,o||[e.responseText,t,e])}}).done(function(e){o=arguments,u.html(i?v("<div>").append(e.replace(yn,"")).find(i):e)}),this},v.each("ajaxStart ajaxStop ajaxComplete ajaxError ajaxSuccess ajaxSend".split(" "),function(e,t){v.fn[t]=function(e){return this.on(t,e)}}),v.each(["get","post"],function(e,n){v[n]=function(e,r,i,s){return v.isFunction(r)&&(s=s||i,i=r,r=t),v.ajax({type:n,url:e,data:r,success:i,dataType:s})}}),v.extend({getScript:function(e,n){return v.get(e,t,n,"script")},getJSON:function(e,t,n){return v.get(e,t,n,"json")},ajaxSetup:function(e,t){return t?Ln(e,v.ajaxSettings):(t=e,e=v.ajaxSettings),Ln(e,t),e},ajaxSettings:{url:cn,isLocal:dn.test(ln[1]),global:!0,type:"GET",contentType:"application/x-www-form-urlencoded; charset=UTF-8",processData:!0,async:!0,accepts:{xml:"application/xml, text/xml",html:"text/html",text:"text/plain",json:"application/json, text/javascript","*":Tn},contents:{xml:/xml/,html:/html/,json:/json/},responseFields:{xml:"responseXML",text:"responseText"},converters:{"* text":e.String,"text html":!0,"text json":v.parseJSON,"text xml":v.parseXML},flatOptions:{context:!0,url:!0}},ajaxPrefilter:Cn(Sn),ajaxTransport:Cn(xn),ajax:function(e,n){function T(e,n,s,a){var l,y,b,w,S,T=n;if(E===2)return;E=2,u&&clearTimeout(u),o=t,i=a||"",x.readyState=e>0?4:0,s&&(w=An(c,x,s));if(e>=200&&e<300||e===304)c.ifModified&&(S=x.getResponseHeader("Last-Modified"),S&&(v.lastModified[r]=S),S=x.getResponseHeader("Etag"),S&&(v.etag[r]=S)),e===304?(T="notmodified",l=!0):(l=On(c,w),T=l.state,y=l.data,b=l.error,l=!b);else{b=T;if(!T||e)T="error",e<0&&(e=0)}x.status=e,x.statusText=(n||T)+"",l?d.resolveWith(h,[y,T,x]):d.rejectWith(h,[x,T,b]),x.statusCode(g),g=t,f&&p.trigger("ajax"+(l?"Success":"Error"),[x,c,l?y:b]),m.fireWith(h,[x,T]),f&&(p.trigger("ajaxComplete",[x,c]),--v.active||v.event.trigger("ajaxStop"))}typeof e=="object"&&(n=e,e=t),n=n||{};var r,i,s,o,u,a,f,l,c=v.ajaxSetup({},n),h=c.context||c,p=h!==c&&(h.nodeType||h instanceof v)?v(h):v.event,d=v.Deferred(),m=v.Callbacks("once memory"),g=c.statusCode||{},b={},w={},E=0,S="canceled",x={readyState:0,setRequestHeader:function(e,t){if(!E){var n=e.toLowerCase();e=w[n]=w[n]||e,b[e]=t}return this},getAllResponseHeaders:function(){return E===2?i:null},getResponseHeader:function(e){var n;if(E===2){if(!s){s={};while(n=pn.exec(i))s[n[1].toLowerCase()]=n[2]}n=s[e.toLowerCase()]}return n===t?null:n},overrideMimeType:function(e){return E||(c.mimeType=e),this},abort:function(e){return e=e||S,o&&o.abort(e),T(0,e),this}};d.promise(x),x.success=x.done,x.error=x.fail,x.complete=m.add,x.statusCode=function(e){if(e){var t;if(E<2)for(t in e)g[t]=[g[t],e[t]];else t=e[x.status],x.always(t)}return this},c.url=((e||c.url)+"").replace(hn,"").replace(mn,ln[1]+"//"),c.dataTypes=v.trim(c.dataType||"*").toLowerCase().split(y),c.crossDomain==null&&(a=wn.exec(c.url.toLowerCase()),c.crossDomain=!(!a||a[1]===ln[1]&&a[2]===ln[2]&&(a[3]||(a[1]==="http:"?80:443))==(ln[3]||(ln[1]==="http:"?80:443)))),c.data&&c.processData&&typeof c.data!="string"&&(c.data=v.param(c.data,c.traditional)),kn(Sn,c,n,x);if(E===2)return x;f=c.global,c.type=c.type.toUpperCase(),c.hasContent=!vn.test(c.type),f&&v.active++===0&&v.event.trigger("ajaxStart");if(!c.hasContent){c.data&&(c.url+=(gn.test(c.url)?"&":"?")+c.data,delete c.data),r=c.url;if(c.cache===!1){var N=v.now(),C=c.url.replace(bn,"$1_="+N);c.url=C+(C===c.url?(gn.test(c.url)?"&":"?")+"_="+N:"")}}(c.data&&c.hasContent&&c.contentType!==!1||n.contentType)&&x.setRequestHeader("Content-Type",c.contentType),c.ifModified&&(r=r||c.url,v.lastModified[r]&&x.setRequestHeader("If-Modified-Since",v.lastModified[r]),v.etag[r]&&x.setRequestHeader("If-None-Match",v.etag[r])),x.setRequestHeader("Accept",c.dataTypes[0]&&c.accepts[c.dataTypes[0]]?c.accepts[c.dataTypes[0]]+(c.dataTypes[0]!=="*"?", "+Tn+"; q=0.01":""):c.accepts["*"]);for(l in c.headers)x.setRequestHeader(l,c.headers[l]);if(!c.beforeSend||c.beforeSend.call(h,x,c)!==!1&&E!==2){S="abort";for(l in{success:1,error:1,complete:1})x[l](c[l]);o=kn(xn,c,n,x);if(!o)T(-1,"No Transport");else{x.readyState=1,f&&p.trigger("ajaxSend",[x,c]),c.async&&c.timeout>0&&(u=setTimeout(function(){x.abort("timeout")},c.timeout));try{E=1,o.send(b,T)}catch(k){if(!(E<2))throw k;T(-1,k)}}return x}return x.abort()},active:0,lastModified:{},etag:{}});var Mn=[],_n=/\?/,Dn=/(=)\?(?=&|$)|\?\?/,Pn=v.now();v.ajaxSetup({jsonp:"callback",jsonpCallback:function(){var e=Mn.pop()||v.expando+"_"+Pn++;return this[e]=!0,e}}),v.ajaxPrefilter("json jsonp",function(n,r,i){var s,o,u,a=n.data,f=n.url,l=n.jsonp!==!1,c=l&&Dn.test(f),h=l&&!c&&typeof a=="string"&&!(n.contentType||"").indexOf("application/x-www-form-urlencoded")&&Dn.test(a);if(n.dataTypes[0]==="jsonp"||c||h)return s=n.jsonpCallback=v.isFunction(n.jsonpCallback)?n.jsonpCallback():n.jsonpCallback,o=e[s],c?n.url=f.replace(Dn,"$1"+s):h?n.data=a.replace(Dn,"$1"+s):l&&(n.url+=(_n.test(f)?"&":"?")+n.jsonp+"="+s),n.converters["script json"]=function(){return u||v.error(s+" was not called"),u[0]},n.dataTypes[0]="json",e[s]=function(){u=arguments},i.always(function(){e[s]=o,n[s]&&(n.jsonpCallback=r.jsonpCallback,Mn.push(s)),u&&v.isFunction(o)&&o(u[0]),u=o=t}),"script"}),v.ajaxSetup({accepts:{script:"text/javascript, application/javascript, application/ecmascript, application/x-ecmascript"},contents:{script:/javascript|ecmascript/},converters:{"text script":function(e){return v.globalEval(e),e}}}),v.ajaxPrefilter("script",function(e){e.cache===t&&(e.cache=!1),e.crossDomain&&(e.type="GET",e.global=!1)}),v.ajaxTransport("script",function(e){if(e.crossDomain){var n,r=i.head||i.getElementsByTagName("head")[0]||i.documentElement;return{send:function(s,o){n=i.createElement("script"),n.async="async",e.scriptCharset&&(n.charset=e.scriptCharset),n.src=e.url,n.onload=n.onreadystatechange=function(e,i){if(i||!n.readyState||/loaded|complete/.test(n.readyState))n.onload=n.onreadystatechange=null,r&&n.parentNode&&r.removeChild(n),n=t,i||o(200,"success")},r.insertBefore(n,r.firstChild)},abort:function(){n&&n.onload(0,1)}}}});var Hn,Bn=e.ActiveXObject?function(){for(var e in Hn)Hn[e](0,1)}:!1,jn=0;v.ajaxSettings.xhr=e.ActiveXObject?function(){return!this.isLocal&&Fn()||In()}:Fn,function(e){v.extend(v.support,{ajax:!!e,cors:!!e&&"withCredentials"in e})}(v.ajaxSettings.xhr()),v.support.ajax&&v.ajaxTransport(function(n){if(!n.crossDomain||v.support.cors){var r;return{send:function(i,s){var o,u,a=n.xhr();n.username?a.open(n.type,n.url,n.async,n.username,n.password):a.open(n.type,n.url,n.async);if(n.xhrFields)for(u in n.xhrFields)a[u]=n.xhrFields[u];n.mimeType&&a.overrideMimeType&&a.overrideMimeType(n.mimeType),!n.crossDomain&&!i["X-Requested-With"]&&(i["X-Requested-With"]="XMLHttpRequest");try{for(u in i)a.setRequestHeader(u,i[u])}catch(f){}a.send(n.hasContent&&n.data||null),r=function(e,i){var u,f,l,c,h;try{if(r&&(i||a.readyState===4)){r=t,o&&(a.onreadystatechange=v.noop,Bn&&delete Hn[o]);if(i)a.readyState!==4&&a.abort();else{u=a.status,l=a.getAllResponseHeaders(),c={},h=a.responseXML,h&&h.documentElement&&(c.xml=h);try{c.text=a.responseText}catch(p){}try{f=a.statusText}catch(p){f=""}!u&&n.isLocal&&!n.crossDomain?u=c.text?200:404:u===1223&&(u=204)}}}catch(d){i||s(-1,d)}c&&s(u,f,c,l)},n.async?a.readyState===4?setTimeout(r,0):(o=++jn,Bn&&(Hn||(Hn={},v(e).unload(Bn)),Hn[o]=r),a.onreadystatechange=r):r()},abort:function(){r&&r(0,1)}}}});var qn,Rn,Un=/^(?:toggle|show|hide)$/,zn=new RegExp("^(?:([-+])=|)("+m+")([a-z%]*)$","i"),Wn=/queueHooks$/,Xn=[Gn],Vn={"*":[function(e,t){var n,r,i=this.createTween(e,t),s=zn.exec(t),o=i.cur(),u=+o||0,a=1,f=20;if(s){n=+s[2],r=s[3]||(v.cssNumber[e]?"":"px");if(r!=="px"&&u){u=v.css(i.elem,e,!0)||n||1;do a=a||".5",u/=a,v.style(i.elem,e,u+r);while(a!==(a=i.cur()/o)&&a!==1&&--f)}i.unit=r,i.start=u,i.end=s[1]?u+(s[1]+1)*n:n}return i}]};v.Animation=v.extend(Kn,{tweener:function(e,t){v.isFunction(e)?(t=e,e=["*"]):e=e.split(" ");var n,r=0,i=e.length;for(;r<i;r++)n=e[r],Vn[n]=Vn[n]||[],Vn[n].unshift(t)},prefilter:function(e,t){t?Xn.unshift(e):Xn.push(e)}}),v.Tween=Yn,Yn.prototype={constructor:Yn,init:function(e,t,n,r,i,s){this.elem=e,this.prop=n,this.easing=i||"swing",this.options=t,this.start=this.now=this.cur(),this.end=r,this.unit=s||(v.cssNumber[n]?"":"px")},cur:function(){var e=Yn.propHooks[this.prop];return e&&e.get?e.get(this):Yn.propHooks._default.get(this)},run:function(e){var t,n=Yn.propHooks[this.prop];return this.options.duration?this.pos=t=v.easing[this.easing](e,this.options.duration*e,0,1,this.options.duration):this.pos=t=e,this.now=(this.end-this.start)*t+this.start,this.options.step&&this.options.step.call(this.elem,this.now,this),n&&n.set?n.set(this):Yn.propHooks._default.set(this),this}},Yn.prototype.init.prototype=Yn.prototype,Yn.propHooks={_default:{get:function(e){var t;return e.elem[e.prop]==null||!!e.elem.style&&e.elem.style[e.prop]!=null?(t=v.css(e.elem,e.prop,!1,""),!t||t==="auto"?0:t):e.elem[e.prop]},set:function(e){v.fx.step[e.prop]?v.fx.step[e.prop](e):e.elem.style&&(e.elem.style[v.cssProps[e.prop]]!=null||v.cssHooks[e.prop])?v.style(e.elem,e.prop,e.now+e.unit):e.elem[e.prop]=e.now}}},Yn.propHooks.scrollTop=Yn.propHooks.scrollLeft={set:function(e){e.elem.nodeType&&e.elem.parentNode&&(e.elem[e.prop]=e.now)}},v.each(["toggle","show","hide"],function(e,t){var n=v.fn[t];v.fn[t]=function(r,i,s){return r==null||typeof r=="boolean"||!e&&v.isFunction(r)&&v.isFunction(i)?n.apply(this,arguments):this.animate(Zn(t,!0),r,i,s)}}),v.fn.extend({fadeTo:function(e,t,n,r){return this.filter(Gt).css("opacity",0).show().end().animate({opacity:t},e,n,r)},animate:function(e,t,n,r){var i=v.isEmptyObject(e),s=v.speed(t,n,r),o=function(){var t=Kn(this,v.extend({},e),s);i&&t.stop(!0)};return i||s.queue===!1?this.each(o):this.queue(s.queue,o)},stop:function(e,n,r){var i=function(e){var t=e.stop;delete e.stop,t(r)};return typeof e!="string"&&(r=n,n=e,e=t),n&&e!==!1&&this.queue(e||"fx",[]),this.each(function(){var t=!0,n=e!=null&&e+"queueHooks",s=v.timers,o=v._data(this);if(n)o[n]&&o[n].stop&&i(o[n]);else for(n in o)o[n]&&o[n].stop&&Wn.test(n)&&i(o[n]);for(n=s.length;n--;)s[n].elem===this&&(e==null||s[n].queue===e)&&(s[n].anim.stop(r),t=!1,s.splice(n,1));(t||!r)&&v.dequeue(this,e)})}}),v.each({slideDown:Zn("show"),slideUp:Zn("hide"),slideToggle:Zn("toggle"),fadeIn:{opacity:"show"},fadeOut:{opacity:"hide"},fadeToggle:{opacity:"toggle"}},function(e,t){v.fn[e]=function(e,n,r){return this.animate(t,e,n,r)}}),v.speed=function(e,t,n){var r=e&&typeof e=="object"?v.extend({},e):{complete:n||!n&&t||v.isFunction(e)&&e,duration:e,easing:n&&t||t&&!v.isFunction(t)&&t};r.duration=v.fx.off?0:typeof r.duration=="number"?r.duration:r.duration in v.fx.speeds?v.fx.speeds[r.duration]:v.fx.speeds._default;if(r.queue==null||r.queue===!0)r.queue="fx";return r.old=r.complete,r.complete=function(){v.isFunction(r.old)&&r.old.call(this),r.queue&&v.dequeue(this,r.queue)},r},v.easing={linear:function(e){return e},swing:function(e){return.5-Math.cos(e*Math.PI)/2}},v.timers=[],v.fx=Yn.prototype.init,v.fx.tick=function(){var e,n=v.timers,r=0;qn=v.now();for(;r<n.length;r++)e=n[r],!e()&&n[r]===e&&n.splice(r--,1);n.length||v.fx.stop(),qn=t},v.fx.timer=function(e){e()&&v.timers.push(e)&&!Rn&&(Rn=setInterval(v.fx.tick,v.fx.interval))},v.fx.interval=13,v.fx.stop=function(){clearInterval(Rn),Rn=null},v.fx.speeds={slow:600,fast:200,_default:400},v.fx.step={},v.expr&&v.expr.filters&&(v.expr.filters.animated=function(e){return v.grep(v.timers,function(t){return e===t.elem}).length});var er=/^(?:body|html)$/i;v.fn.offset=function(e){if(arguments.length)return e===t?this:this.each(function(t){v.offset.setOffset(this,e,t)});var n,r,i,s,o,u,a,f={top:0,left:0},l=this[0],c=l&&l.ownerDocument;if(!c)return;return(r=c.body)===l?v.offset.bodyOffset(l):(n=c.documentElement,v.contains(n,l)?(typeof l.getBoundingClientRect!="undefined"&&(f=l.getBoundingClientRect()),i=tr(c),s=n.clientTop||r.clientTop||0,o=n.clientLeft||r.clientLeft||0,u=i.pageYOffset||n.scrollTop,a=i.pageXOffset||n.scrollLeft,{top:f.top+u-s,left:f.left+a-o}):f)},v.offset={bodyOffset:function(e){var t=e.offsetTop,n=e.offsetLeft;return v.support.doesNotIncludeMarginInBodyOffset&&(t+=parseFloat(v.css(e,"marginTop"))||0,n+=parseFloat(v.css(e,"marginLeft"))||0),{top:t,left:n}},setOffset:function(e,t,n){var r=v.css(e,"position");r==="static"&&(e.style.position="relative");var i=v(e),s=i.offset(),o=v.css(e,"top"),u=v.css(e,"left"),a=(r==="absolute"||r==="fixed")&&v.inArray("auto",[o,u])>-1,f={},l={},c,h;a?(l=i.position(),c=l.top,h=l.left):(c=parseFloat(o)||0,h=parseFloat(u)||0),v.isFunction(t)&&(t=t.call(e,n,s)),t.top!=null&&(f.top=t.top-s.top+c),t.left!=null&&(f.left=t.left-s.left+h),"using"in t?t.using.call(e,f):i.css(f)}},v.fn.extend({position:function(){if(!this[0])return;var e=this[0],t=this.offsetParent(),n=this.offset(),r=er.test(t[0].nodeName)?{top:0,left:0}:t.offset();return n.top-=parseFloat(v.css(e,"marginTop"))||0,n.left-=parseFloat(v.css(e,"marginLeft"))||0,r.top+=parseFloat(v.css(t[0],"borderTopWidth"))||0,r.left+=parseFloat(v.css(t[0],"borderLeftWidth"))||0,{top:n.top-r.top,left:n.left-r.left}},offsetParent:function(){return this.map(function(){var e=this.offsetParent||i.body;while(e&&!er.test(e.nodeName)&&v.css(e,"position")==="static")e=e.offsetParent;return e||i.body})}}),v.each({scrollLeft:"pageXOffset",scrollTop:"pageYOffset"},function(e,n){var r=/Y/.test(n);v.fn[e]=function(i){return v.access(this,function(e,i,s){var o=tr(e);if(s===t)return o?n in o?o[n]:o.document.documentElement[i]:e[i];o?o.scrollTo(r?v(o).scrollLeft():s,r?s:v(o).scrollTop()):e[i]=s},e,i,arguments.length,null)}}),v.each({Height:"height",Width:"width"},function(e,n){v.each({padding:"inner"+e,content:n,"":"outer"+e},function(r,i){v.fn[i]=function(i,s){var o=arguments.length&&(r||typeof i!="boolean"),u=r||(i===!0||s===!0?"margin":"border");return v.access(this,function(n,r,i){var s;return v.isWindow(n)?n.document.documentElement["client"+e]:n.nodeType===9?(s=n.documentElement,Math.max(n.body["scroll"+e],s["scroll"+e],n.body["offset"+e],s["offset"+e],s["client"+e])):i===t?v.css(n,r,i,u):v.style(n,r,i,u)},n,o?i:t,o,null)}})}),e.jQuery=e.$=v,typeof define=="function"&&define.amd&&define.amd.jQuery&&define("jquery",[],function(){return v})})(window);
+</script>
+<script type="text/javascript">
+/*
+ * jQuery Templates Plugin 1.0.0pre
+ * http://github.com/jquery/jquery-tmpl
+ * Requires jQuery 1.4.2
+ *
+ * Copyright Software Freedom Conservancy, Inc.
+ * Dual licensed under the MIT or GPL Version 2 licenses.
+ * http://jquery.org/license
+ */
+(function(a){var r=a.fn.domManip,d="_tmplitem",q=/^[^<]*(<[\w\W]+>)[^>]*$|\{\{\! /,b={},f={},e,p={key:0,data:{}},i=0,c=0,l=[];function g(g,d,h,e){var c={data:e||(e===0||e===false)?e:d?d.data:{},_wrap:d?d._wrap:null,tmpl:null,parent:d||null,nodes:[],calls:u,nest:w,wrap:x,html:v,update:t};g&&a.extend(c,g,{nodes:[],parent:d});if(h){c.tmpl=h;c._ctnt=c._ctnt||c.tmpl(a,c);c.key=++i;(l.length?f:b)[i]=c}return c}a.each({appendTo:"append",prependTo:"prepend",insertBefore:"before",insertAfter:"after",replaceAll:"replaceWith"},function(f,d){a.fn[f]=function(n){var g=[],i=a(n),k,h,m,l,j=this.length===1&&this[0].parentNode;e=b||{};if(j&&j.nodeType===11&&j.childNodes.length===1&&i.length===1){i[d](this[0]);g=this}else{for(h=0,m=i.length;h<m;h++){c=h;k=(h>0?this.clone(true):this).get();a(i[h])[d](k);g=g.concat(k)}c=0;g=this.pushStack(g,f,i.selector)}l=e;e=null;a.tmpl.complete(l);return g}});a.fn.extend({tmpl:function(d,c,b){return a.tmpl(this[0],d,c,b)},tmplItem:function(){return a.tmplItem(this[0])},template:function(b){return a.template(b,this[0])},domManip:function(d,m,k){if(d[0]&&a.isArray(d[0])){var g=a.makeArray(arguments),h=d[0],j=h.length,i=0,f;while(i<j&&!(f=a.data(h[i++],"tmplItem")));if(f&&c)g[2]=function(b){a.tmpl.afterManip(this,b,k)};r.apply(this,g)}else r.apply(this,arguments);c=0;!e&&a.tmpl.complete(b);return this}});a.extend({tmpl:function(d,h,e,c){var i,k=!c;if(k){c=p;d=a.template[d]||a.template(null,d);f={}}else if(!d){d=c.tmpl;b[c.key]=c;c.nodes=[];c.wrapped&&n(c,c.wrapped);return a(j(c,null,c.tmpl(a,c)))}if(!d)return[];if(typeof h==="function")h=h.call(c||{});e&&e.wrapped&&n(e,e.wrapped);i=a.isArray(h)?a.map(h,function(a){return a?g(e,c,d,a):null}):[g(e,c,d,h)];return k?a(j(c,null,i)):i},tmplItem:function(b){var c;if(b instanceof a)b=b[0];while(b&&b.nodeType===1&&!(c=a.data(b,"tmplItem"))&&(b=b.parentNode));return c||p},template:function(c,b){if(b){if(typeof b==="string")b=o(b);else if(b instanceof a)b=b[0]||{};if(b.nodeType)b=a.data(b,"tmpl")||a.data(b,"tmpl",o(b.innerHTML));return typeof c==="string"?(a.template[c]=b):b}return c?typeof c!=="string"?a.template(null,c):a.template[c]||a.template(null,q.test(c)?c:a(c)):null},encode:function(a){return(""+a).split("&").join("&amp;").split("<").join("&lt;").split(">").join("&gt;").split('"').join("&#34;").split("'").join("&#39;")}});a.extend(a.tmpl,{tag:{tmpl:{_default:{$2:"null"},open:"if($notnull_1){__=__.concat($item.nest($1,$2));}"},wrap:{_default:{$2:"null"},open:"$item.calls(__,$1,$2);__=[];",close:"call=$item.calls();__=call._.concat($item.wrap(call,__));"},each:{_default:{$2:"$index, $value"},open:"if($notnull_1){$.each($1a,function($2){with(this){",close:"}});}"},"if":{open:"if(($notnull_1) && $1a){",close:"}"},"else":{_default:{$1:"true"},open:"}else if(($notnull_1) && $1a){"},html:{open:"if($notnull_1){__.push($1a);}"},"=":{_default:{$1:"$data"},open:"if($notnull_1){__.push($.encode($1a));}"},"!":{open:""}},complete:function(){b={}},afterManip:function(f,b,d){var e=b.nodeType===11?a.makeArray(b.childNodes):b.nodeType===1?[b]:[];d.call(f,b);m(e);c++}});function j(e,g,f){var b,c=f?a.map(f,function(a){return typeof a==="string"?e.key?a.replace(/(<\w+)(?=[\s>])(?![^>]*_tmplitem)([^>]*)/g,"$1 "+d+'="'+e.key+'" $2'):a:j(a,e,a._ctnt)}):e;if(g)return c;c=c.join("");c.replace(/^\s*([^<\s][^<]*)?(<[\w\W]+>)([^>]*[^>\s])?\s*$/,function(f,c,e,d){b=a(e).get();m(b);if(c)b=k(c).concat(b);if(d)b=b.concat(k(d))});return b?b:k(c)}function k(c){var b=document.createElement("div");b.innerHTML=c;return a.makeArray(b.childNodes)}function o(b){return new Function("jQuery","$item","var $=jQuery,call,__=[],$data=$item.data;with($data){__.push('"+a.trim(b).replace(/([\\'])/g,"\\$1").replace(/[\r\t\n]/g," ").replace(/\$\{([^\}]*)\}/g,"{{= $1}}").replace(/\{\{(\/?)(\w+|.)(?:\(((?:[^\}]|\}(?!\}))*?)?\))?(?:\s+(.*?)?)?(\(((?:[^\}]|\}(?!\}))*?)\))?\s*\}\}/g,function(m,l,k,g,b,c,d){var j=a.tmpl.tag[k],i,e,f;if(!j)throw"Unknown template tag: "+k;i=j._default||[];if(c&&!/\w$/.test(b)){b+=c;c=""}if(b){b=h(b);d=d?","+h(d)+")":c?")":"";e=c?b.indexOf(".")>-1?b+h(c):"("+b+").call($item"+d:b;f=c?e:"(typeof("+b+")==='function'?("+b+").call($item):("+b+"))"}else f=e=i.$1||"null";g=h(g);return"');"+j[l?"close":"open"].split("$notnull_1").join(b?"typeof("+b+")!=='undefined' && ("+b+")!=null":"true").split("$1a").join(f).split("$1").join(e).split("$2").join(g||i.$2||"")+"__.push('"})+"');}return __;")}function n(c,b){c._wrap=j(c,true,a.isArray(b)?b:[q.test(b)?b:a(b).html()]).join("")}function h(a){return a?a.replace(/\\'/g,"'").replace(/\\\\/g,"\\"):null}function s(b){var a=document.createElement("div");a.appendChild(b.cloneNode(true));return a.innerHTML}function m(o){var n="_"+c,k,j,l={},e,p,h;for(e=0,p=o.length;e<p;e++){if((k=o[e]).nodeType!==1)continue;j=k.getElementsByTagName("*");for(h=j.length-1;h>=0;h--)m(j[h]);m(k)}function m(j){var p,h=j,k,e,m;if(m=j.getAttribute(d)){while(h.parentNode&&(h=h.parentNode).nodeType===1&&!(p=h.getAttribute(d)));if(p!==m){h=h.parentNode?h.nodeType===11?0:h.getAttribute(d)||0:0;if(!(e=b[m])){e=f[m];e=g(e,b[h]||f[h]);e.key=++i;b[i]=e}c&&o(m)}j.removeAttribute(d)}else if(c&&(e=a.data(j,"tmplItem"))){o(e.key);b[e.key]=e;h=a.data(j.parentNode,"tmplItem");h=h?h.key:0}if(e){k=e;while(k&&k.key!=h){k.nodes.push(j);k=k.parent}delete e._ctnt;delete e._wrap;a.data(j,"tmplItem",e)}function o(a){a=a+n;e=l[a]=l[a]||g(e,b[e.parent.key+n]||e.parent)}}}function u(a,d,c,b){if(!a)return l.pop();l.push({_:a,tmpl:d,item:this,data:c,options:b})}function w(d,c,b){return a.tmpl(a.template(d),c,b,this)}function x(b,d){var c=b.options||{};c.wrapped=d;return a.tmpl(a.template(b.tmpl),b.data,c,b.item)}function v(d,c){var b=this._wrap;return a.map(a(a.isArray(b)?b.join(""):b).filter(d||"*"),function(a){return c?a.innerText||a.textContent:a.outerHTML||s(a)})}function t(){var b=this.nodes;a.tmpl(null,null,null,this).insertBefore(b[0]);a(b).remove()}})(jQuery);
+</script>
+<script type="text/javascript">
+/*!
+* TableSorter 2.7.8 min - Client-side table sorting with ease!
+* Copyright (c) 2007 Christian Bach
+*/
+!function(j){j.extend({tablesorter:new function(){function e(d){"undefined"!==typeof console&&"undefined"!==typeof console.log?console.log(d):alert(d)}function u(d,c){e(d+" ("+((new Date).getTime()-c.getTime())+"ms)")}function p(d,c,a){if(!c)return"";var b=d.config,g=b.textExtraction,f="",f="simple"===g?b.supportsTextContent?c.textContent:j(c).text():"function"===typeof g?g(c,d,a):"object"===typeof g&&g.hasOwnProperty(a)?g[a](c,d,a):b.supportsTextContent?c.textContent:j(c).text();return j.trim(f)} function h(d){var c=d.config,a=c.$tbodies=c.$table.children("tbody:not(."+c.cssInfoBlock+")"),b,q,f,l,j,n,k="";if(0===a.length)return c.debug?e("*Empty table!* Not building a parser cache"):"";a=a[0].rows;if(a[0]){b=[];q=a[0].cells.length;for(f=0;f<q;f++){l=c.$headers.filter(":not([colspan])");l=l.add(c.$headers.filter('[colspan="1"]')).filter('[data-column="'+f+'"]:last');j=c.headers[f];n=g.getParserById(g.getData(l,j,"sorter"));c.empties[f]=g.getData(l,j,"empty")||c.emptyTo||(c.emptyToBottom?"bottom": "top");c.strings[f]=g.getData(l,j,"string")||c.stringTo||"max";if(!n)a:{l=d;j=a;n=-1;for(var u=f,x=void 0,t=g.parsers.length,y=!1,m="",x=!0;""===m&&x;)n++,j[n]?(y=j[n].cells[u],m=p(l,y,u),l.config.debug&&e("Checking if value was empty on row "+n+", column: "+u+": "+m)):x=!1;for(x=1;x<t;x++)if(g.parsers[x].is&&g.parsers[x].is(m,l,y)){n=g.parsers[x];break a}n=g.parsers[0]}c.debug&&(k+="column:"+f+"; parser:"+n.id+"; string:"+c.strings[f]+"; empty: "+c.empties[f]+"\n");b.push(n)}}c.debug&&e(k);return b} function s(d){var c=d.tBodies,a=d.config,b,q,f=a.parsers,l,v,n,k,h,x,t,m=[];a.cache={};if(!f)return a.debug?e("*Empty table!* Not building a cache"):"";a.debug&&(t=new Date);a.showProcessing&&g.isProcessing(d,!0);for(k=0;k<c.length;k++)if(a.cache[k]={row:[],normalized:[]},!j(c[k]).hasClass(a.cssInfoBlock)){b=c[k]&&c[k].rows.length||0;q=c[k].rows[0]&&c[k].rows[0].cells.length||0;for(v=0;v<b;++v)if(h=j(c[k].rows[v]),x=[],h.hasClass(a.cssChildRow))a.cache[k].row[a.cache[k].row.length-1]=a.cache[k].row[a.cache[k].row.length- 1].add(h);else{a.cache[k].row.push(h);for(n=0;n<q;++n)if(l=p(d,h[0].cells[n],n),l=f[n].format(l,d,h[0].cells[n],n),x.push(l),"numeric"===(f[n].type||"").toLowerCase())m[n]=Math.max(Math.abs(l),m[n]||0);x.push(a.cache[k].normalized.length);a.cache[k].normalized.push(x)}a.cache[k].colMax=m}a.showProcessing&&g.isProcessing(d);a.debug&&u("Building cache for "+b+" rows",t)}function m(d,c){var a=d.config,b=d.tBodies,q=[],f=a.cache,e,v,n,k,h,p,m,y,s,r,E;if(f[0]){a.debug&&(E=new Date);for(y=0;y<b.length;y++)if(e= j(b[y]),!e.hasClass(a.cssInfoBlock)){h=g.processTbody(d,e,!0);e=f[y].row;v=f[y].normalized;k=(n=v.length)?v[0].length-1:0;for(p=0;p<n;p++)if(r=v[p][k],q.push(e[r]),!a.appender||!a.removeRows){s=e[r].length;for(m=0;m<s;m++)h.append(e[r][m])}g.processTbody(d,h,!1)}a.appender&&a.appender(d,q);a.debug&&u("Rebuilt table",E);c||g.applyWidget(d);j(d).trigger("sortEnd",d)}}function F(d){var c,a,b,g=d.config,f=g.sortList,e=[g.cssAsc,g.cssDesc],h=j(d).find("tfoot tr").children().removeClass(e.join(" "));g.$headers.removeClass(e.join(" ")); b=f.length;for(c=0;c<b;c++)if(2!==f[c][1]&&(d=g.$headers.not(".sorter-false").filter('[data-column="'+f[c][0]+'"]'+(1===b?":last":"")),d.length))for(a=0;a<d.length;a++)d[a].sortDisabled||(d.eq(a).addClass(e[f[c][1]]),h.length&&h.filter('[data-column="'+f[c][0]+'"]').eq(a).addClass(e[f[c][1]]))}function G(d){var c=0,a=d.config,b=a.sortList,g=b.length,f=d.tBodies.length,e,h,n,k,p,m,t,r,s;if(!a.serverSideSorting&&a.cache[0]){a.debug&&(e=new Date);for(n=0;n<f;n++)p=a.cache[n].colMax,s=(m=a.cache[n].normalized)&& m[0]?m[0].length-1:0,m.sort(function(f,e){for(h=0;h<g;h++){k=b[h][0];r=b[h][1];t=/n/i.test(a.parsers&&a.parsers[k]?a.parsers[k].type||"":"")?"Numeric":"Text";t+=0===r?"":"Desc";/Numeric/.test(t)&&a.strings[k]&&(c="boolean"===typeof a.string[a.strings[k]]?(0===r?1:-1)*(a.string[a.strings[k]]?-1:1):a.strings[k]?a.string[a.strings[k]]||0:0);var l=j.tablesorter["sort"+t](d,f[k],e[k],k,p[k],c);if(l)return l}return f[s]-e[s]});a.debug&&u("Sorting on "+b.toString()+" and dir "+r+" time",e)}}function C(d, c){d.trigger("updateComplete");"function"===typeof c&&c(d[0])}function I(d,c,a){!1!==c?d.trigger("sorton",[d[0].config.sortList,function(){C(d,a)}]):C(d,a)}var g=this;g.version="2.7.8";g.parsers=[];g.widgets=[];g.defaults={theme:"default",widthFixed:!1,showProcessing:!1,headerTemplate:"{content}",onRenderTemplate:null,onRenderHeader:null,cancelSelection:!0,dateFormat:"mmddyyyy",sortMultiSortKey:"shiftKey",sortResetKey:"ctrlKey",usNumberFormat:!0,delayInit:!1,serverSideSorting:!1,headers:{},ignoreCase:!0, sortForce:null,sortList:[],sortAppend:null,sortInitialOrder:"asc",sortLocaleCompare:!1,sortReset:!1,sortRestart:!1,emptyTo:"bottom",stringTo:"max",textExtraction:"simple",textSorter:null,widgets:[],widgetOptions:{zebra:["even","odd"]},initWidgets:!0,initialized:null,tableClass:"tablesorter",cssAsc:"tablesorter-headerAsc",cssChildRow:"tablesorter-childRow",cssDesc:"tablesorter-headerDesc",cssHeader:"tablesorter-header",cssHeaderRow:"tablesorter-headerRow",cssIcon:"tablesorter-icon",cssInfoBlock:"tablesorter-infoOnly", cssProcessing:"tablesorter-processing",selectorHeaders:"> thead th, > thead td",selectorSort:"th, td",selectorRemove:".remove-me",debug:!1,headerList:[],empties:{},strings:{},parsers:[]};g.benchmark=u;g.construct=function(d){return this.each(function(){if(!this.tHead||0===this.tBodies.length||!0===this.hasInitialized)return this.config&&this.config.debug?e("stopping initialization! No thead, tbody or tablesorter has already been initialized"):"";var c=j(this),a=this,b,q,f,l="",v,n,k,C,x=j.metadata; a.hasInitialized=!1;a.config={};b=j.extend(!0,a.config,g.defaults,d);j.data(a,"tablesorter",b);b.debug&&j.data(a,"startoveralltimer",new Date);b.supportsTextContent="x"===j("<span>x</span>")[0].textContent;b.supportsDataObject=1.4<=parseFloat(j.fn.jquery);b.string={max:1,min:-1,"max+":1,"max-":-1,zero:0,none:0,"null":0,top:!0,bottom:!1};/tablesorter\-/.test(c.attr("class"))||(l=""!==b.theme?" tablesorter-"+b.theme:"");b.$table=c.addClass(b.tableClass+l);b.$tbodies=c.children("tbody:not(."+b.cssInfoBlock+ ")");var t=[],y={},O=0,R=j(a).find("thead:eq(0), tfoot").children("tr"),E,K,z,A,P,D,L,S,T,H;for(E=0;E<R.length;E++){P=R[E].cells;for(K=0;K<P.length;K++){A=P[K];D=A.parentNode.rowIndex;L=D+"-"+A.cellIndex;S=A.rowSpan||1;T=A.colSpan||1;"undefined"===typeof t[D]&&(t[D]=[]);for(z=0;z<t[D].length+1;z++)if("undefined"===typeof t[D][z]){H=z;break}y[L]=H;O=Math.max(H,O);j(A).attr({"data-column":H});for(z=D;z<D+S;z++){"undefined"===typeof t[z]&&(t[z]=[]);L=t[z];for(A=H;A<H+T;A++)L[A]="x"}}}a.config.columns= O;var M,B,Q,U,N,J,V,w=a.config;w.headerList=[];w.headerContent=[];w.debug&&(V=new Date);U=w.cssIcon?'<i class="'+w.cssIcon+'"></i>':"";t=j(a).find(w.selectorHeaders).each(function(a){B=j(this);M=w.headers[a];w.headerContent[a]=this.innerHTML;N=w.headerTemplate.replace(/\{content\}/g,this.innerHTML).replace(/\{icon\}/g,U);w.onRenderTemplate&&(Q=w.onRenderTemplate.apply(B,[a,N]))&&"string"===typeof Q&&(N=Q);this.innerHTML='<div class="tablesorter-header-inner">'+N+"</div>";w.onRenderHeader&&w.onRenderHeader.apply(B, [a]);this.column=y[this.parentNode.rowIndex+"-"+this.cellIndex];var b=g.getData(B,M,"sortInitialOrder")||w.sortInitialOrder;this.order=/^d/i.test(b)||1===b?[1,0,2]:[0,1,2];this.count=-1;"false"===g.getData(B,M,"sorter")?(this.sortDisabled=!0,B.addClass("sorter-false")):B.removeClass("sorter-false");this.lockedOrder=!1;J=g.getData(B,M,"lockedOrder")||!1;"undefined"!==typeof J&&!1!==J&&(this.order=this.lockedOrder=/^d/i.test(J)||1===J?[1,1,1]:[0,0,0]);B.addClass((this.sortDisabled?"sorter-false ":" ")+ w.cssHeader);w.headerList[a]=this;B.parent().addClass(w.cssHeaderRow)});a.config.debug&&(u("Built headers:",V),e(t));b.$headers=t;if(a.config.widthFixed&&0===j(a).find("colgroup").length){var W=j("<colgroup>"),X=j(a).width();j("tr:first td",a.tBodies[0]).each(function(){W.append(j("<col>").css("width",parseInt(1E3*(j(this).width()/X),10)/10+"%"))});j(a).prepend(W)}b.parsers=h(a);b.delayInit||s(a);b.$headers.find("*")[j.fn.addBack?"addBack":"andSelf"]().filter(b.selectorSort).unbind("mousedown.tablesorter mouseup.tablesorter").bind("mousedown.tablesorter mouseup.tablesorter", function(d,e){var h=(this.tagName.match("TH|TD")?j(this):j(this).parents("th, td").filter(":last"))[0];if(1!==(d.which||d.button))return!1;if("mousedown"===d.type)return C=(new Date).getTime(),"INPUT"===d.target.tagName?"":!b.cancelSelection;if(!0!==e&&250<(new Date).getTime()-C)return!1;b.delayInit&&!b.cache&&s(a);if(!h.sortDisabled){c.trigger("sortStart",a);l=!d[b.sortMultiSortKey];h.count=d[b.sortResetKey]?2:(h.count+1)%(b.sortReset?3:2);b.sortRestart&&(q=h,b.$headers.each(function(){if(this!== q&&(l||!j(this).is("."+b.cssDesc+",."+b.cssAsc)))this.count=-1}));q=h.column;if(l){b.sortList=[];if(null!==b.sortForce){v=b.sortForce;for(f=0;f<v.length;f++)v[f][0]!==q&&b.sortList.push(v[f])}k=h.order[h.count];if(2>k&&(b.sortList.push([q,k]),1<h.colSpan))for(f=1;f<h.colSpan;f++)b.sortList.push([q+f,k])}else if(b.sortAppend&&1<b.sortList.length&&g.isValueInArray(b.sortAppend[0][0],b.sortList)&&b.sortList.pop(),g.isValueInArray(q,b.sortList))for(f=0;f<b.sortList.length;f++)n=b.sortList[f],k=b.headerList[n[0]], n[0]===q&&(n[1]=k.order[k.count],2===n[1]&&(b.sortList.splice(f,1),k.count=-1));else if(k=h.order[h.count],2>k&&(b.sortList.push([q,k]),1<h.colSpan))for(f=1;f<h.colSpan;f++)b.sortList.push([q+f,k]);if(null!==b.sortAppend){v=b.sortAppend;for(f=0;f<v.length;f++)v[f][0]!==q&&b.sortList.push(v[f])}c.trigger("sortBegin",a);setTimeout(function(){F(a);G(a);m(a)},1)}});b.cancelSelection&&b.$headers.each(function(){this.onselectstart=function(){return!1}});c.unbind("sortReset update updateCell addRows sorton appendCache applyWidgetId applyWidgets refreshWidgets destroy mouseup mouseleave ".split(" ").join(".tablesorter ")).bind("sortReset.tablesorter", function(){b.sortList=[];F(a);G(a);m(a)}).bind("update.tablesorter updateRows.tablesorter",function(d,f,g){j(b.selectorRemove,a).remove();b.parsers=h(a);s(a);I(c,f,g)}).bind("updateCell.tablesorter",function(d,f,g,e){var q,h,l;q=c.find("tbody");d=q.index(j(f).parents("tbody").filter(":last"));var k=j(f).parents("tr").filter(":last");f=j(f)[0];q.length&&0<=d&&(h=q.eq(d).find("tr").index(k),l=f.cellIndex,q=a.config.cache[d].normalized[h].length-1,a.config.cache[d].row[a.config.cache[d].normalized[h][q]]= k,a.config.cache[d].normalized[h][l]=b.parsers[l].format(p(a,f,l),a,f,l),I(c,g,e))}).bind("addRows.tablesorter",function(d,g,e,q){var j=g.filter("tr").length,l=[],k=g[0].cells.length,n=c.find("tbody").index(g.closest("tbody"));b.parsers||(b.parsers=h(a));for(d=0;d<j;d++){for(f=0;f<k;f++)l[f]=b.parsers[f].format(p(a,g[d].cells[f],f),a,g[d].cells[f],f);l.push(b.cache[n].row.length);b.cache[n].row.push([g[d]]);b.cache[n].normalized.push(l);l=[]}I(c,e,q)}).bind("sorton.tablesorter",function(b,d,f,g){c.trigger("sortStart", this);var e,q,l,h=a.config;b=d||h.sortList;h.sortList=[];j.each(b,function(a,b){e=[parseInt(b[0],10),parseInt(b[1],10)];if(l=h.headerList[e[0]])h.sortList.push(e),q=j.inArray(e[1],l.order),l.count=0<=q?q:e[1]%(h.sortReset?3:2)});F(a);G(a);m(a,g);"function"===typeof f&&f(a)}).bind("appendCache.tablesorter",function(b,c,d){m(a,d);"function"===typeof c&&c(a)}).bind("applyWidgetId.tablesorter",function(c,d){g.getWidgetById(d).format(a,b,b.widgetOptions)}).bind("applyWidgets.tablesorter",function(b,c){g.applyWidget(a, c)}).bind("refreshWidgets.tablesorter",function(b,c,d){g.refreshWidgets(a,c,d)}).bind("destroy.tablesorter",function(b,c,d){g.destroy(a,c,d)});b.supportsDataObject&&"undefined"!==typeof c.data().sortlist?b.sortList=c.data().sortlist:x&&(c.metadata()&&c.metadata().sortlist)&&(b.sortList=c.metadata().sortlist);g.applyWidget(a,!0);0<b.sortList.length?c.trigger("sorton",[b.sortList,{},!b.initWidgets]):b.initWidgets&&g.applyWidget(a);b.showProcessing&&c.unbind("sortBegin.tablesorter sortEnd.tablesorter").bind("sortBegin.tablesorter sortEnd.tablesorter", function(b){g.isProcessing(a,"sortBegin"===b.type)});a.hasInitialized=!0;b.debug&&g.benchmark("Overall initialization time",j.data(a,"startoveralltimer"));c.trigger("tablesorter-initialized",a);"function"===typeof b.initialized&&b.initialized(a)})};g.isProcessing=function(d,c,a){var b=d.config;d=a||j(d).find("."+b.cssHeader);c?(0<b.sortList.length&&(d=d.filter(function(){return this.sortDisabled?!1:g.isValueInArray(parseFloat(j(this).attr("data-column")),b.sortList)})),d.addClass(b.cssProcessing)): d.removeClass(b.cssProcessing)};g.processTbody=function(d,c,a){if(a)return c.before('<span class="tablesorter-savemyplace"/>'),d=j.fn.detach?c.detach():c.remove();d=j(d).find("span.tablesorter-savemyplace");c.insertAfter(d);d.remove()};g.clearTableBody=function(d){d.config.$tbodies.empty()};g.destroy=function(d,c,a){if(d.hasInitialized){g.refreshWidgets(d,!0,!0);var b=j(d),e=d.config,f=b.find("thead:first"),h=f.find("tr."+e.cssHeaderRow).removeClass(e.cssHeaderRow),u=b.find("tfoot:first > tr").children("th, td"); f.find("tr").not(h).remove();b.removeData("tablesorter").unbind("sortReset update updateCell addRows sorton appendCache applyWidgetId applyWidgets refreshWidgets destroy mouseup mouseleave sortBegin sortEnd ".split(" ").join(".tablesorter "));e.$headers.add(u).removeClass(e.cssHeader+" "+e.cssAsc+" "+e.cssDesc).removeAttr("data-column");h.find(e.selectorSort).unbind("mousedown.tablesorter mouseup.tablesorter");h.children().each(function(a){j(this).html(e.headerContent[a])});!1!==c&&b.removeClass(e.tableClass+ " tablesorter-"+e.theme);d.hasInitialized=!1;"function"===typeof a&&a(d)}};g.regex=[/(^([+\-]?(?:0|[1-9]\d*)(?:\.\d*)?(?:[eE][+\-]?\d+)?)?$|^0x[0-9a-f]+$|\d+)/gi,/(^([\w ]+,?[\w ]+)?[\w ]+,?[\w ]+\d+:\d+(:\d+)?[\w ]?|^\d{1,4}[\/\-]\d{1,4}[\/\-]\d{1,4}|^\w+, \w+ \d+, \d{4})/,/^0x[0-9a-f]+$/i];g.sortText=function(d,c,a,b){if(c===a)return 0;var e=d.config,f=e.string[e.empties[b]||e.emptyTo],h=g.regex;if(""===c&&0!==f)return"boolean"===typeof f?f?-1:1:-f||-1;if(""===a&&0!==f)return"boolean"===typeof f? f?1:-1:f||1;if("function"===typeof e.textSorter)return e.textSorter(c,a,d,b);d=c.replace(h[0],"\\0$1\\0").replace(/\\0$/,"").replace(/^\\0/,"").split("\\0");b=a.replace(h[0],"\\0$1\\0").replace(/\\0$/,"").replace(/^\\0/,"").split("\\0");c=parseInt(c.match(h[2]),16)||1!==d.length&&c.match(h[1])&&Date.parse(c);if(a=parseInt(a.match(h[2]),16)||c&&a.match(h[1])&&Date.parse(a)||null){if(c<a)return-1;if(c>a)return 1}e=Math.max(d.length,b.length);for(c=0;c<e;c++){a=isNaN(d[c])?d[c]||0:parseFloat(d[c])|| 0;h=isNaN(b[c])?b[c]||0:parseFloat(b[c])||0;if(isNaN(a)!==isNaN(h))return isNaN(a)?1:-1;typeof a!==typeof h&&(a+="",h+="");if(a<h)return-1;if(a>h)return 1}return 0};g.sortTextDesc=function(d,c,a,b){if(c===a)return 0;var e=d.config,f=e.string[e.empties[b]||e.emptyTo];return""===c&&0!==f?"boolean"===typeof f?f?-1:1:f||1:""===a&&0!==f?"boolean"===typeof f?f?1:-1:-f||-1:"function"===typeof e.textSorter?e.textSorter(a,c,d,b):g.sortText(d,a,c)};g.getTextValue=function(d,c,a){if(c){var b=d.length,e=c+a; for(c=0;c<b;c++)e+=d.charCodeAt(c);return a*e}return 0};g.sortNumeric=function(d,c,a,b,e,f){if(c===a)return 0;d=d.config;b=d.string[d.empties[b]||d.emptyTo];if(""===c&&0!==b)return"boolean"===typeof b?b?-1:1:-b||-1;if(""===a&&0!==b)return"boolean"===typeof b?b?1:-1:b||1;isNaN(c)&&(c=g.getTextValue(c,e,f));isNaN(a)&&(a=g.getTextValue(a,e,f));return c-a};g.sortNumericDesc=function(d,c,a,b,e,f){if(c===a)return 0;d=d.config;b=d.string[d.empties[b]||d.emptyTo];if(""===c&&0!==b)return"boolean"===typeof b? b?-1:1:b||1;if(""===a&&0!==b)return"boolean"===typeof b?b?1:-1:-b||-1;isNaN(c)&&(c=g.getTextValue(c,e,f));isNaN(a)&&(a=g.getTextValue(a,e,f));return a-c};g.characterEquivalents={a:"\u00e1\u00e0\u00e2\u00e3\u00e4\u0105\u00e5",A:"\u00c1\u00c0\u00c2\u00c3\u00c4\u0104\u00c5",c:"\u00e7\u0107\u010d",C:"\u00c7\u0106\u010c",e:"\u00e9\u00e8\u00ea\u00eb\u011b\u0119",E:"\u00c9\u00c8\u00ca\u00cb\u011a\u0118",i:"\u00ed\u00ec\u0130\u00ee\u00ef\u0131",I:"\u00cd\u00cc\u0130\u00ce\u00cf",o:"\u00f3\u00f2\u00f4\u00f5\u00f6", O:"\u00d3\u00d2\u00d4\u00d5\u00d6",ss:"\u00df",SS:"\u1e9e",u:"\u00fa\u00f9\u00fb\u00fc\u016f",U:"\u00da\u00d9\u00db\u00dc\u016e"};g.replaceAccents=function(d){var c,a="[",b=g.characterEquivalents;if(!g.characterRegex){g.characterRegexArray={};for(c in b)"string"===typeof c&&(a+=b[c],g.characterRegexArray[c]=RegExp("["+b[c]+"]","g"));g.characterRegex=RegExp(a+"]")}if(g.characterRegex.test(d))for(c in b)"string"===typeof c&&(d=d.replace(g.characterRegexArray[c],c));return d};g.isValueInArray=function(d, c){var a,b=c.length;for(a=0;a<b;a++)if(c[a][0]===d)return!0;return!1};g.addParser=function(d){var c,a=g.parsers.length,b=!0;for(c=0;c<a;c++)g.parsers[c].id.toLowerCase()===d.id.toLowerCase()&&(b=!1);b&&g.parsers.push(d)};g.getParserById=function(d){var c,a=g.parsers.length;for(c=0;c<a;c++)if(g.parsers[c].id.toLowerCase()===d.toString().toLowerCase())return g.parsers[c];return!1};g.addWidget=function(d){g.widgets.push(d)};g.getWidgetById=function(d){var c,a,b=g.widgets.length;for(c=0;c<b;c++)if((a= g.widgets[c])&&a.hasOwnProperty("id")&&a.id.toLowerCase()===d.toLowerCase())return a};g.applyWidget=function(d,c){var a=d.config,b=a.widgetOptions,e=a.widgets.sort().reverse(),f,h,m,n=e.length;h=j.inArray("zebra",a.widgets);0<=h&&(a.widgets.splice(h,1),a.widgets.push("zebra"));a.debug&&(f=new Date);for(h=0;h<n;h++)(m=g.getWidgetById(e[h]))&&(!0===c&&m.hasOwnProperty("init")?m.init(d,m,a,b):!c&&m.hasOwnProperty("format")&&m.format(d,a,b));a.debug&&u("Completed "+(!0===c?"initializing":"applying")+ " widgets",f)};g.refreshWidgets=function(d,c,a){var b,h=d.config,f=h.widgets,l=g.widgets,m=l.length;for(b=0;b<m;b++)if(l[b]&&l[b].id&&(c||0>j.inArray(l[b].id,f)))h.debug&&e("Refeshing widgets: Removing "+l[b].id),l[b].hasOwnProperty("remove")&&l[b].remove(d,h,h.widgetOptions);!0!==a&&g.applyWidget(d,c)};g.getData=function(d,c,a){var b="";d=j(d);var e,f;if(!d.length)return"";e=j.metadata?d.metadata():!1;f=" "+(d.attr("class")||"");"undefined"!==typeof d.data(a)||"undefined"!==typeof d.data(a.toLowerCase())? b+=d.data(a)||d.data(a.toLowerCase()):e&&"undefined"!==typeof e[a]?b+=e[a]:c&&"undefined"!==typeof c[a]?b+=c[a]:" "!==f&&f.match(" "+a+"-")&&(b=f.match(RegExp(" "+a+"-(\\w+)"))[1]||"");return j.trim(b)};g.formatFloat=function(d,c){if("string"!==typeof d||""===d)return d;var a;d=(c&&c.config?!1!==c.config.usNumberFormat:"undefined"!==typeof c?c:1)?d.replace(/,/g,""):d.replace(/[\s|\.]/g,"").replace(/,/g,".");/^\s*\([.\d]+\)/.test(d)&&(d=d.replace(/^\s*\(/,"-").replace(/\)/,""));a=parseFloat(d);return isNaN(a)? j.trim(d):a};g.isDigit=function(d){return isNaN(d)?/^[\-+(]?\d+[)]?$/.test(d.toString().replace(/[,.'"\s]/g,"")):!0}}});var h=j.tablesorter;j.fn.extend({tablesorter:h.construct});h.addParser({id:"text",is:function(){return!0},format:function(e,u){var p=u.config;e=j.trim(p.ignoreCase?e.toLocaleLowerCase():e);return p.sortLocaleCompare?h.replaceAccents(e):e},type:"text"});h.addParser({id:"currency",is:function(e){return/^\(?\d+[\u00a3$\u20ac\u00a4\u00a5\u00a2?.]|[\u00a3$\u20ac\u00a4\u00a5\u00a2?.]\d+\)?$/.test((e|| "").replace(/[,. ]/g,""))},format:function(e,j){return h.formatFloat(e.replace(/[^\w,. \-()]/g,""),j)},type:"numeric"});h.addParser({id:"ipAddress",is:function(e){return/^\d{1,3}[\.]\d{1,3}[\.]\d{1,3}[\.]\d{1,3}$/.test(e)},format:function(e,j){var p,r=e.split("."),s="",m=r.length;for(p=0;p<m;p++)s+=("00"+r[p]).slice(-3);return h.formatFloat(s,j)},type:"numeric"});h.addParser({id:"url",is:function(e){return/^(https?|ftp|file):\/\//.test(e)},format:function(e){return j.trim(e.replace(/(https?|ftp|file):\/\//, ""))},type:"text"});h.addParser({id:"isoDate",is:function(e){return/^\d{4}[\/\-]\d{1,2}[\/\-]\d{1,2}/.test(e)},format:function(e,j){return h.formatFloat(""!==e?(new Date(e.replace(/-/g,"/"))).getTime()||"":"",j)},type:"numeric"});h.addParser({id:"percent",is:function(e){return/(\d\s?%|%\s?\d)/.test(e)},format:function(e,j){return h.formatFloat(e.replace(/%/g,""),j)},type:"numeric"});h.addParser({id:"usLongDate",is:function(e){return/^[A-Z]{3,10}\.?\s+\d{1,2},?\s+(\d{4})(\s+\d{1,2}:\d{2}(:\d{2})?(\s+[AP]M)?)?$/i.test(e)|| /^\d{1,2}\s+[A-Z]{3,10}\s+\d{4}/i.test(e)},format:function(e,j){return h.formatFloat((new Date(e.replace(/(\S)([AP]M)$/i,"$1 $2"))).getTime()||"",j)},type:"numeric"});h.addParser({id:"shortDate",is:function(e){return/^(\d{1,2}|\d{4})[\/\-\,\.\s+]\d{1,2}[\/\-\.\,\s+](\d{1,2}|\d{4})$/.test(e)},format:function(e,j,p,r){p=j.config;var s=p.headerList[r],m=s.shortDateFormat;"undefined"===typeof m&&(m=s.shortDateFormat=h.getData(s,p.headers[r],"dateFormat")||p.dateFormat);e=e.replace(/\s+/g," ").replace(/[\-|\.|\,]/g, "/");"mmddyyyy"===m?e=e.replace(/(\d{1,2})[\/\s](\d{1,2})[\/\s](\d{4})/,"$3/$1/$2"):"ddmmyyyy"===m?e=e.replace(/(\d{1,2})[\/\s](\d{1,2})[\/\s](\d{4})/,"$3/$2/$1"):"yyyymmdd"===m&&(e=e.replace(/(\d{4})[\/\s](\d{1,2})[\/\s](\d{1,2})/,"$1/$2/$3"));return h.formatFloat((new Date(e)).getTime()||"",j)},type:"numeric"});h.addParser({id:"time",is:function(e){return/^(([0-2]?\d:[0-5]\d)|([0-1]?\d:[0-5]\d\s?([AP]M)))$/i.test(e)},format:function(e,j){return h.formatFloat((new Date("2000/01/01 "+e.replace(/(\S)([AP]M)$/i, "$1 $2"))).getTime()||"",j)},type:"numeric"});h.addParser({id:"digit",is:function(e){return h.isDigit(e)},format:function(e,j){return h.formatFloat(e.replace(/[^\w,. \-()]/g,""),j)},type:"numeric"});h.addParser({id:"metadata",is:function(){return!1},format:function(e,h,p){e=h.config;e=!e.parserMetadataName?"sortValue":e.parserMetadataName;return j(p).metadata()[e]},type:"numeric"});h.addWidget({id:"zebra",format:function(e,u,p){var r,s,m,F,G,C,I=RegExp(u.cssChildRow,"i"),g=u.$tbodies;u.debug&&(G= new Date);for(e=0;e<g.length;e++)r=g.eq(e),C=r.children("tr").length,1<C&&(m=0,r=r.children("tr:visible"),r.each(function(){s=j(this);I.test(this.className)||m++;F=0===m%2;s.removeClass(p.zebra[F?1:0]).addClass(p.zebra[F?0:1])}));u.debug&&h.benchmark("Applying Zebra widget",G)},remove:function(e,h){var p,r,s=h.$tbodies,m=(h.widgetOptions.zebra||["even","odd"]).join(" ");for(p=0;p<s.length;p++)r=j.tablesorter.processTbody(e,s.eq(p),!0),r.children().removeClass(m),j.tablesorter.processTbody(e,r,!1)}})}(jQuery);
+</script>
+<script type="text/javascript">
+/*
+    Copyright 2008-2013
+        Matthias Ehmann,
+        Michael Gerhaeuser,
+        Carsten Miller,
+        Bianca Valentin,
+        Alfred Wassermann,
+        Peter Wilfahrt
+    Dual licensed under the Apache License Version 2.0, or LGPL Version 3 licenses.
+    You should have received a copy of the GNU Lesser General Public License
+    along with JSXCompressor.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the Apache License along with JSXCompressor.
+    If not, see <http://www.apache.org/licenses/>.
+*/
+(function(){var e,r,n;(function(t){function o(e,r){return y.call(e,r)}function i(e,r){var n,t,o,i,u,f,a,c,s,l,p=r&&r.split("/"),d=k.map,g=d&&d["*"]||{};if(e&&"."===e.charAt(0))if(r){for(p=p.slice(0,p.length-1),e=p.concat(e.split("/")),c=0;e.length>c;c+=1)if(l=e[c],"."===l)e.splice(c,1),c-=1;else if(".."===l){if(1===c&&(".."===e[2]||".."===e[0]))break;c>0&&(e.splice(c-1,2),c-=2)}e=e.join("/")}else 0===e.indexOf("./")&&(e=e.substring(2));if((p||g)&&d){for(n=e.split("/"),c=n.length;c>0;c-=1){if(t=n.slice(0,c).join("/"),p)for(s=p.length;s>0;s-=1)if(o=d[p.slice(0,s).join("/")],o&&(o=o[t])){i=o,u=c;break}if(i)break;!f&&g&&g[t]&&(f=g[t],a=c)}!i&&f&&(i=f,u=a),i&&(n.splice(0,u,i),e=n.join("/"))}return e}function u(e,r){return function(){return d.apply(t,v.call(arguments,0).concat([e,r]))}}function f(e){return function(r){return i(r,e)}}function a(e){return function(r){b[e]=r}}function c(e){if(o(m,e)){var r=m[e];delete m[e],C[e]=!0,p.apply(t,r)}if(!o(b,e)&&!o(C,e))throw Error("No "+e);return b[e]}function s(e){var r,n=e?e.indexOf("!"):-1;return n>-1&&(r=e.substring(0,n),e=e.substring(n+1,e.length)),[r,e]}function l(e){return function(){return k&&k.config&&k.config[e]||{}}}var p,d,g,h,b={},m={},k={},C={},y=Object.prototype.hasOwnProperty,v=[].slice;g=function(e,r){var n,t=s(e),o=t[0];return e=t[1],o&&(o=i(o,r),n=c(o)),o?e=n&&n.normalize?n.normalize(e,f(r)):i(e,r):(e=i(e,r),t=s(e),o=t[0],e=t[1],o&&(n=c(o))),{f:o?o+"!"+e:e,n:e,pr:o,p:n}},h={require:function(e){return u(e)},exports:function(e){var r=b[e];return r!==void 0?r:b[e]={}},module:function(e){return{id:e,uri:"",exports:b[e],config:l(e)}}},p=function(e,r,n,i){var f,s,l,p,d,k,y=[];if(i=i||e,"function"==typeof n){for(r=!r.length&&n.length?["require","exports","module"]:r,d=0;r.length>d;d+=1)if(p=g(r[d],i),s=p.f,"require"===s)y[d]=h.require(e);else if("exports"===s)y[d]=h.exports(e),k=!0;else if("module"===s)f=y[d]=h.module(e);else if(o(b,s)||o(m,s)||o(C,s))y[d]=c(s);else{if(!p.p)throw Error(e+" missing "+s);p.p.load(p.n,u(i,!0),a(s),{}),y[d]=b[s]}l=n.apply(b[e],y),e&&(f&&f.exports!==t&&f.exports!==b[e]?b[e]=f.exports:l===t&&k||(b[e]=l))}else e&&(b[e]=n)},e=r=d=function(e,r,n,o,i){return"string"==typeof e?h[e]?h[e](r):c(g(e,r).f):(e.splice||(k=e,r.splice?(e=r,r=n,n=null):e=t),r=r||function(){},"function"==typeof n&&(n=o,o=i),o?p(t,e,r,n):setTimeout(function(){p(t,e,r,n)},4),d)},d.config=function(e){return k=e,k.deps&&d(k.deps,k.callback),d},n=function(e,r,n){r.splice||(n=r,r=[]),o(b,e)||o(m,e)||(m[e]=[e,r,n])},n.amd={jQuery:!0}})(),n("../node_modules/almond/almond",function(){}),n("jxg",[],function(){var e={};return"object"!=typeof JXG||JXG.extend||(e=JXG),e.extend=function(e,r,n,t){var o,i;n=n||!1,t=t||!1;for(o in r)(!n||n&&r.hasOwnProperty(o))&&(i=t?o.toLowerCase():o,e[i]=r[o])},e.extend(e,{boards:{},readers:{},elements:{},registerElement:function(e,r){e=e.toLowerCase(),this.elements[e]=r},registerReader:function(e,r){var n,t;for(n=0;r.length>n;n++)t=r[n].toLowerCase(),"function"!=typeof this.readers[t]&&(this.readers[t]=e)},shortcut:function(e,r){return function(){return e[r].apply(this,arguments)}},getRef:function(e,r){return e.select(r)},getReference:function(e,r){return e.select(r)},debugInt:function(){var e,r;for(e=0;arguments.length>e;e++)r=arguments[e],"object"==typeof window&&window.console&&console.log?console.log(r):"object"==typeof document&&document.getElementById("debug")&&(document.getElementById("debug").innerHTML+=r+"<br/>")},debugWST:function(){var r=Error();e.debugInt.apply(this,arguments),r&&r.stack&&(e.debugInt("stacktrace"),e.debugInt(r.stack.split("\n").slice(1).join("\n")))},debugLine:function(){var r=Error();e.debugInt.apply(this,arguments),r&&r.stack&&e.debugInt("Called from",r.stack.split("\n").slice(2,3).join("\n"))},debug:function(){e.debugInt.apply(this,arguments)}}),e}),n("utils/zip",["jxg"],function(e){var r=[0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240,8,136,72,200,40,168,104,232,24,152,88,216,56,184,120,248,4,132,68,196,36,164,100,228,20,148,84,212,52,180,116,244,12,140,76,204,44,172,108,236,28,156,92,220,60,188,124,252,2,130,66,194,34,162,98,226,18,146,82,210,50,178,114,242,10,138,74,202,42,170,106,234,26,154,90,218,58,186,122,250,6,134,70,198,38,166,102,230,22,150,86,214,54,182,118,246,14,142,78,206,46,174,110,238,30,158,94,222,62,190,126,254,1,129,65,193,33,161,97,225,17,145,81,209,49,177,113,241,9,137,73,201,41,169,105,233,25,153,89,217,57,185,121,249,5,133,69,197,37,165,101,229,21,149,85,213,53,181,117,245,13,141,77,205,45,173,109,237,29,157,93,221,61,189,125,253,3,131,67,195,35,163,99,227,19,147,83,211,51,179,115,243,11,139,75,203,43,171,107,235,27,155,91,219,59,187,123,251,7,135,71,199,39,167,103,231,23,151,87,215,55,183,119,247,15,143,79,207,47,175,111,239,31,159,95,223,63,191,127,255],n=[3,4,5,6,7,8,9,10,11,13,15,17,19,23,27,31,35,43,51,59,67,83,99,115,131,163,195,227,258,0,0],t=[0,0,0,0,0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3,4,4,4,4,5,5,5,5,0,99,99],o=[1,2,3,4,5,7,9,13,17,25,33,49,65,97,129,193,257,385,513,769,1025,1537,2049,3073,4097,6145,8193,12289,16385,24577],i=[0,0,0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,9,9,10,10,11,11,12,12,13,13],u=[16,17,18,0,8,7,9,6,10,5,11,4,12,3,13,2,14,1,15],f=256;return e.Util=e.Util||{},e.Util.Unzip=function(a){function c(){return q+=8,N>R?a[R++]:-1}function s(){T=1}function l(){var e;return q++,e=1&T,T>>=1,0===T&&(T=c(),e=1&T,T=128|T>>1),e}function p(e){for(var n=0,t=e;t--;)n=n<<1|l();return e&&(n=r[n]>>8-e),n}function d(){L=0}function g(e){A++,E[L++]=e,z.push(String.fromCharCode(e)),32768===L&&(L=0)}function h(){this.b0=0,this.b1=0,this.jump=null,this.jumppos=-1}function b(){for(;;){if(H[P]>=w)return-1;if(U[H[P]]===P)return H[P]++;H[P]++}}function m(){var e,r=F[X];if(17===P)return-1;if(X++,P++,e=b(),e>=0)r.b0=e;else if(r.b0=32768,m())return-1;if(e=b(),e>=0)r.b1=e,r.jump=null;else if(r.b1=32768,r.jump=F[X],r.jumppos=X,m())return-1;return P--,0}function k(e,r,n){var t;for(F=e,X=0,U=n,w=r,t=0;17>t;t++)H[t]=0;return P=0,m()?-1:0}function C(e){for(var r,n,t,o=0,i=e[o];;)if(t=l()){if(!(32768&i.b1))return i.b1;for(i=i.jump,r=e.length,n=0;r>n;n++)if(e[n]===i){o=n;break}}else{if(!(32768&i.b0))return i.b0;o++,i=e[o]}}function y(){var f,a,b,m,y,v,j,A,x,U,w,S,z,I,O,B,N;do if(f=l(),b=p(2),0===b)for(s(),U=c(),U|=c()<<8,S=c(),S|=c()<<8,65535&(U^~S)&&e.debug("BlockLen checksum mismatch\n");U--;)a=c(),g(a);else if(1===b)for(;;)if(y=r[p(7)]>>1,y>23?(y=y<<1|l(),y>199?(y-=128,y=y<<1|l()):(y-=48,y>143&&(y+=136))):y+=256,256>y)g(y);else{if(256===y)break;for(y-=257,x=p(t[y])+n[y],y=r[p(5)]>>3,i[y]>8?(w=p(8),w|=p(i[y]-8)<<8):w=p(i[y]),w+=o[y],y=0;x>y;y++)a=E[32767&L-w],g(a)}else if(2===b){for(j=Array(320),I=257+p(5),O=1+p(5),B=4+p(4),y=0;19>y;y++)j[y]=0;for(y=0;B>y;y++)j[u[y]]=p(3);for(x=J.length,m=0;x>m;m++)J[m]=new h;if(k(J,19,j,0))return d(),1;for(z=I+O,m=0,N=-1;z>m;)if(N++,y=C(J),16>y)j[m++]=y;else if(16===y){if(y=3+p(2),m+y>z)return d(),1;for(v=m?j[m-1]:0;y--;)j[m++]=v}else{if(y=17===y?3+p(3):11+p(7),m+y>z)return d(),1;for(;y--;)j[m++]=0}for(x=G.length,m=0;x>m;m++)G[m]=new h;if(k(G,I,j,0))return d(),1;for(x=G.length,m=0;x>m;m++)J[m]=new h;for(A=[],m=I;j.length>m;m++)A[m-I]=j[m];if(k(J,O,A,0))return d(),1;for(;;)if(y=C(G),y>=256){if(y-=256,0===y)break;for(y-=1,x=p(t[y])+n[y],y=C(J),i[y]>8?(w=p(8),w|=p(i[y]-8)<<8):w=p(i[y]),w+=o[y];x--;)a=E[32767&L-w],g(a)}else g(y)}while(!f);return d(),s(),0}function v(){var e,r,n,t,o,i,u,a,s=[];if(z=[],B=!1,s[0]=c(),s[1]=c(),120===s[0]&&218===s[1]&&(y(),O[I]=[z.join(""),"geonext.gxt"],I++),31===s[0]&&139===s[1]&&(S(),O[I]=[z.join(""),"file"],I++),80===s[0]&&75===s[1]&&(B=!0,s[2]=c(),s[3]=c(),3===s[2]&&4===s[3])){for(s[0]=c(),s[1]=c(),j=c(),j|=c()<<8,a=c(),a|=c()<<8,c(),c(),c(),c(),u=c(),u|=c()<<8,u|=c()<<16,u|=c()<<24,i=c(),i|=c()<<8,i|=c()<<16,i|=c()<<24,o=c(),o|=c()<<8,o|=c()<<16,o|=c()<<24,t=c(),t|=c()<<8,n=c(),n|=c()<<8,e=0,M=[];t--;)r=c(),"/"===r|":"===r?e=0:f-1>e&&(M[e++]=String.fromCharCode(r));for(x||(x=M),e=0;n>e;)r=c(),e++;A=0,8===a&&(y(),O[I]=Array(2),O[I][0]=z.join(""),O[I][1]=M.join(""),I++),S()}}var j,A,x,U,w,S,z=[],I=0,O=[],E=Array(32768),L=0,B=!1,N=a.length,R=0,T=1,q=0,G=Array(288),J=Array(32),X=0,F=null,P=(Array(64),Array(64),0),H=Array(17),M=[];H[0]=0,S=function(){var e,r,n,t,o,i,u=[];if(8&j&&(u[0]=c(),u[1]=c(),u[2]=c(),u[3]=c(),80===u[0]&&75===u[1]&&7===u[2]&&8===u[3]?(e=c(),e|=c()<<8,e|=c()<<16,e|=c()<<24):e=u[0]|u[1]<<8|u[2]<<16|u[3]<<24,r=c(),r|=c()<<8,r|=c()<<16,r|=c()<<24,n=c(),n|=c()<<8,n|=c()<<16,n|=c()<<24),B&&v(),u[0]=c(),8===u[0]){if(j=c(),c(),c(),c(),c(),c(),t=c(),4&j)for(u[0]=c(),u[2]=c(),P=u[0]+256*u[1],o=0;P>o;o++)c();if(8&j)for(o=0,M=[],i=c();i;)("7"===i||":"===i)&&(o=0),f-1>o&&(M[o++]=i),i=c();if(16&j)for(i=c();i;)i=c();2&j&&(c(),c()),y(),e=c(),e|=c()<<8,e|=c()<<16,e|=c()<<24,n=c(),n|=c()<<8,n|=c()<<16,n|=c()<<24,B&&v()}},e.Util.Unzip.prototype.unzipFile=function(e){var r;for(this.unzip(),r=0;O.length>r;r++)if(O[r][1]===e)return O[r][0];return""},e.Util.Unzip.prototype.unzip=function(){return v(),O}},e.Util}),n("utils/encoding",["jxg"],function(e){var r=0,n=[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,8,8,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,10,3,3,3,3,3,3,3,3,3,3,3,3,4,3,3,11,6,6,6,5,8,8,8,8,8,8,8,8,8,8,8,0,12,24,36,60,96,84,12,12,12,48,72,12,12,12,12,12,12,12,12,12,12,12,12,12,0,12,12,12,12,12,0,12,0,12,12,12,24,12,12,12,12,12,24,12,24,12,12,12,12,12,12,12,12,12,24,12,12,12,12,12,24,12,12,12,12,12,12,12,24,12,12,12,12,12,12,12,12,12,36,12,36,12,12,12,36,12,12,12,12,12,36,12,36,12,12,12,36,12,12,12,12,12,12,12,12,12,12];return e.Util=e.Util||{},e.Util.UTF8={encode:function(e){var r,n,t="",o=e.length;if(e=e.replace(/\r\n/g,"\n"),"function"==typeof unescape&&"function"==typeof encodeURIComponent)return unescape(encodeURIComponent(e));for(r=0;o>r;r++)n=e.charCodeAt(r),128>n?t+=String.fromCharCode(n):n>127&&2048>n?(t+=String.fromCharCode(192|n>>6),t+=String.fromCharCode(128|63&n)):(t+=String.fromCharCode(224|n>>12),t+=String.fromCharCode(128|63&n>>6),t+=String.fromCharCode(128|63&n));return t},decode:function(e){var t,o,i,u=0,f=0,a=r,c=[],s=e.length,l=[];for(t=0;s>t;t++)o=e.charCodeAt(t),i=n[o],f=a!==r?63&o|f<<6:255>>i&o,a=n[256+a+i],a===r&&(f>65535?c.push(55232+(f>>10),56320+(1023&f)):c.push(f),u++,0===u%1e4&&(l.push(String.fromCharCode.apply(null,c)),c=[]));return l.push(String.fromCharCode.apply(null,c)),l.join("")},asciiCharCodeAt:function(e,r){var n=e.charCodeAt(r);if(n>255)switch(n){case 8364:n=128;break;case 8218:n=130;break;case 402:n=131;break;case 8222:n=132;break;case 8230:n=133;break;case 8224:n=134;break;case 8225:n=135;break;case 710:n=136;break;case 8240:n=137;break;case 352:n=138;break;case 8249:n=139;break;case 338:n=140;break;case 381:n=142;break;case 8216:n=145;break;case 8217:n=146;break;case 8220:n=147;break;case 8221:n=148;break;case 8226:n=149;break;case 8211:n=150;break;case 8212:n=151;break;case 732:n=152;break;case 8482:n=153;break;case 353:n=154;break;case 8250:n=155;break;case 339:n=156;break;case 382:n=158;break;case 376:n=159;break;default:}return n}},e.Util.UTF8}),n("utils/base64",["jxg","utils/encoding"],function(e,r){var n="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";return e.Util=e.Util||{},e.Util.Base64={encode:function(e){var t,o,i,u,f,a,c,s=[],l=0;for(e=r.encode(e);e.length>l;)t=e.charCodeAt(l++),o=e.charCodeAt(l++),i=e.charCodeAt(l++),u=t>>2,f=(3&t)<<4|o>>4,a=(15&o)<<2|i>>6,c=63&i,isNaN(o)?a=c=64:isNaN(i)&&(c=64),s.push([n.charAt(u),n.charAt(f),n.charAt(a),n.charAt(c)].join(""));return s.join("")},decode:function(e,t){var o,i,u,f,a,c,s,l=[],p=0,d=e.length;for(e=e.replace(/[^A-Za-z0-9\+\/\=]/g,"");d>p;)f=n.indexOf(e.charAt(p++)),a=n.indexOf(e.charAt(p++)),c=n.indexOf(e.charAt(p++)),s=n.indexOf(e.charAt(p++)),o=f<<2|a>>4,i=(15&a)<<4|c>>2,u=(3&c)<<6|s,l.push(String.fromCharCode(o)),64!==c&&l.push(String.fromCharCode(i)),64!==s&&l.push(String.fromCharCode(u));return l=l.join(""),t&&(l=r.decode(l)),l},decodeAsArray:function(e){var r,n=this.decode(e),t=[],o=n.length;for(r=0;o>r;r++)t[r]=n.charCodeAt(r);return t}},e.Util.Base64}),n("../build/compressor.deps.js",["jxg","utils/zip","utils/base64"],function(e,r,n){return e.decompress=function(e){return unescape(new r.Unzip(n.decodeAsArray(e)).unzip()[0][0])},e}),window.JXG=r("../build/compressor.deps.js")})();
+</script>
+<script type="text/javascript">
+window.fileLoading = (function () {
+    var fileLoadingCallbacks = {};
+    var timestamp = new Date().getTime();
+    function loadKeywordsFile(filename, callback) {
+        fileLoadingCallbacks[filename] = callback;
+        var script = document.createElement('script');
+        script.type = 'text/javascript';
+        // timestamp as an argument to prevent browsers from caching scripts
+        // see: http://stackoverflow.com/questions/866619/how-to-force-ie-to-reload-javascript
+        script.src = filename+'?time='+timestamp;
+        document.getElementsByTagName("head")[0].appendChild(script);
+    }
+    function getCallbackHandlerForKeywords(parent) {
+        var callableList = [];
+        return function (callable) {
+            if (!parent.isChildrenLoaded) {
+                callableList.push(callable);
+                if (callableList.length == 1) {
+                    loadKeywordsFile(parent.childFileName, function () {
+                        parent.isChildrenLoaded = true;
+                        for (var i = 0; i < callableList.length; i++) {
+                            callableList[i]();
+                        }
+                    });
+                }
+            } else {
+                callable();
+            }
+        }
+    }
+    function notifyFileLoaded(filename) {
+        fileLoadingCallbacks[filename]();
+    }
+    return {
+        getCallbackHandlerForKeywords: getCallbackHandlerForKeywords,
+        notify: notifyFileLoaded
+    }
+}());
+</script>
+<script type="text/javascript">
+window.model = (function () {
+    function Suite(data) {
+        var suite = createModelObject(data);
+        suite.source = data.source;
+        suite.relativeSource = data.relativeSource;
+        suite.fullName = data.parent ? data.parent.fullName + '.' + data.name : data.name;
+        setStats(suite, data.statistics);
+        suite.metadata = data.metadata;
+        suite.populateKeywords = createIterablePopulator('Keyword');
+        suite.populateTests = createIterablePopulator('Test');
+        suite.populateSuites = createIterablePopulator('Suite');
+        suite.childrenNames = ['keyword', 'suite', 'test'];
+        suite.callWhenChildrenReady = function (callable) { callable(); };
+        suite.message = data.message;
+        suite.children = function () {
+            return suite.keywords().concat(suite.tests()).concat(suite.suites());
+        };
+        suite.searchTests = function (predicate) {
+            var tests = [];
+            var suites = this.suites();
+            for (var i in suites)
+                tests = tests.concat(suites[i].searchTests(predicate));
+            return tests.concat(util.filter(this.tests(), predicate));
+        };
+        suite.searchTestsInSuite = function (pattern, matcher) {
+            if (!matcher)
+                matcher = util.Matcher(pattern);
+            if (matcher.matchesAny([suite.fullName, suite.name]))
+                return suite.allTests();
+            var tests = [];
+            var suites = this.suites();
+            for (var i in suites)
+                tests = tests.concat(suites[i].searchTestsInSuite(pattern, matcher));
+            return tests;
+        };
+        suite.searchTestsByTag = function (tag) {
+            return suite.searchTests(function (test) {
+                if (tag.combined)
+                    return containsTagPattern(test.tags, tag.combined);
+                return containsTag(test.tags, tag.label);
+            });
+        };
+        suite.findSuiteByName = function (name) {
+            return findSuiteByName(suite, name);
+        };
+        suite.allTests = function () {
+            return suite.searchTests(function (test) {
+                return true;
+            });
+        };
+        suite.criticalTests = function () {
+            return suite.searchTests(function (test) {
+                return test.isCritical;
+            });
+        };
+        return suite;
+    }
+    function containsTag(testTags, tagname) {
+        testTags = util.map(testTags, util.normalize);
+        return util.contains(testTags, util.normalize(tagname));
+    }
+    function containsTagPattern(testTags, pattern) {
+        var patterns;
+        if (pattern.indexOf('NOT') != -1) {
+            patterns = pattern.split('NOT');
+            if (!util.normalize(patterns[0]))
+                return util.all(util.map(patterns.slice(1), function (p) {
+                    return !containsTagPattern(testTags, p);
+                }));
+            return containsTagPattern(testTags, patterns[0]) &&
+                util.all(util.map(patterns.slice(1), function (p) {
+                    return !containsTagPattern(testTags, p);
+                }));
+        }
+        if (pattern.indexOf('OR') != -1) {
+            patterns = pattern.split('OR');
+            return util.any(util.map(patterns, function (p) {
+                return containsTagPattern(testTags, p);
+            }));
+        }
+        if (pattern.indexOf('AND') != -1) {
+            patterns = pattern.split('AND');
+            return util.all(util.map(patterns, function (p) {
+                return containsTagPattern(testTags, p);
+            }));
+        }
+        return util.Matcher(pattern).matchesAny(testTags);
+    }
+    function findSuiteByName(suite, name) {
+        if (suite.fullName == name)
+            return suite;
+        var subSuites = suite.suites();
+        for (var i in subSuites) {
+            var match = findSuiteByName(subSuites[i], name);
+            if (match)
+                return match;
+        }
+        return null;
+    }
+    function setStats(suite, stats) {
+        for (var name in stats) {
+            suite[name] = stats[name];
+        }
+    }
+    function createModelObject(data) {
+        return {
+            name: data.name,
+            doc: data.doc,
+            status: data.status,
+            times: data.times,
+            id: data.parent ? data.parent.id + '-' + data.id : data.id
+        };
+    }
+    function Test(data) {
+        var test = createModelObject(data);
+        test.fullName = data.parent.fullName + '.' + test.name;
+        test.formatParentName = function () { return util.formatParentName(test); };
+        test.timeout = data.timeout;
+        test.populateKeywords = createIterablePopulator('Keyword');
+        test.childrenNames = ['keyword'];
+        test.isChildrenLoaded = data.isChildrenLoaded;
+        test.callWhenChildrenReady = window.fileLoading.getCallbackHandlerForKeywords(test);
+        test.children = function () {
+            if (test.isChildrenLoaded)
+                return test.keywords();
+        };
+        test.isCritical = data.isCritical;
+        test.tags = data.tags;
+        test.message = data.message;
+        test.matchesTagPattern = function (pattern) {
+            return containsTagPattern(test.tags, pattern);
+        };
+        test.matchesNamePattern = function (pattern) {
+            return util.Matcher(pattern).matchesAny([test.name, test.fullName]);
+        };
+        return test;
+    }
+    function Keyword(data) {
+        var kw = createModelObject(data);
+        kw.libname = data.libname;
+        kw.type = data.type;
+        kw.arguments = data.args;
+        kw.assign = data.assign + (data.assign ? ' =' : '');
+        kw.tags = data.tags;
+        kw.timeout = data.timeout;
+        kw.populateMessages = createIterablePopulator('Message');
+        kw.populateKeywords = createIterablePopulator('Keyword');
+        kw.childrenNames = ['keyword', 'message'];
+        kw.isChildrenLoaded = data.isChildrenLoaded;
+        kw.callWhenChildrenReady = window.fileLoading.getCallbackHandlerForKeywords(kw);
+        kw.children = function () {
+            if (kw.isChildrenLoaded)
+                return kw.keywords();
+        };
+        return kw;
+    }
+    function Message(level, date, text, link) {
+        return {
+            level: level,
+            time: util.timeFromDate(date),
+            date: util.dateFromDate(date),
+            text: text,
+            link: link
+        };
+    }
+    function Times(timedata) {
+        var start = timedata[0];
+        var end = timedata[1];
+        var elapsed = timedata[2];
+        return {
+            elapsedMillis: elapsed,
+            elapsedTime: util.formatElapsed(elapsed),
+            startTime: util.dateTimeFromDate(start),
+            endTime:  util.dateTimeFromDate(end)
+        };
+    }
+    function createIterablePopulator(name) {
+        return function (populator) {
+            populateIterable(this, name, populator);
+        };
+    }
+    function populateIterable(obj, name, populator) {
+        name = name.toLowerCase() + 's';
+        obj[name] = createGetAllFunction(populator.numberOfItems, populator.creator);
+    }
+    function createGetAllFunction(numberOfElements, creator) {
+        var cached = null;
+        return function () {
+            if (cached === null) {
+                cached = [];
+                for (var i = 0; i < numberOfElements(); i++) {
+                    cached.push(creator(i));
+                }
+            }
+            return cached;
+        };
+    }
+    return {
+        Suite: Suite,
+        Test: Test,
+        Keyword: Keyword,
+        Message: Message,
+        Times: Times,
+        containsTag: containsTag,  // Exposed for tests
+        containsTagPattern: containsTagPattern  // Exposed for tests
+    };
+}());
+window.stats = (function () {
+    function Statistics(totalElems, tagElems, suiteElems) {
+        return {total: util.map(totalElems, totalStatElem),
+                tag:   util.map(tagElems, tagStatElem),
+                suite: util.map(suiteElems, suiteStatElem)};
+    }
+    function statElem(stat) {
+        stat.total = stat.pass + stat.fail;
+        var percents = calculatePercents(stat.total, stat.pass, stat.fail);
+        stat.passPercent = percents[0];
+        stat.failPercent = percents[1];
+        var widths = calculateWidths(stat.passPercent, stat.failPercent);
+        stat.passWidth = widths[0];
+        stat.failWidth = widths[1];
+        return stat;
+    }
+    function totalStatElem(data) {
+        var stat = statElem(data);
+        stat.type = stat.label == 'Critical Tests' ? 'critical' : 'all';
+        return stat;
+    }
+    function tagStatElem(data) {
+        var stat = statElem(data);
+        stat.links = parseLinks(stat.links);
+        return stat;
+    }
+    function suiteStatElem(data) {
+        var stat = statElem(data);
+        stat.fullName = stat.label;
+        stat.formatParentName = function () { return util.formatParentName(stat); };
+        // compatibility with RF 2.5 outputs
+        if (!stat.name)
+            stat.name = stat.label.split('.').pop();
+        return stat;
+    }
+    function parseLinks(linksData) {
+        if (!linksData)
+            return [];
+        return util.map(linksData.split(':::'), function (link) {
+                var index = link.indexOf(':');
+                return {title: link.slice(0, index), url: link.slice(index+1)};
+            });
+    }
+    function calculatePercents(total, passed, failed) {
+        if (total == 0)
+            return [0.0, 0.0];
+        var pass = 100.0 * passed / total;
+        var fail = 100.0 * failed / total;
+        if (pass > 0 && pass < 0.1)
+            return [0.1, 99.9];
+        if (fail > 0 && fail < 0.1)
+            return [99.9, 0.1];
+        return [Math.round(pass*10)/10, Math.round(fail*10)/10];
+    }
+    function calculateWidths(num1, num2) {
+        if (num1 + num2 == 0)
+            return [0.0, 0.0];
+        // Make small percentages better visible
+        if (num1 > 0 && num1 < 1)
+            return [1.0, 99.0];
+        if (num2 > 0 && num2 < 1)
+            return [99.0, 1.0];
+        // Handle situation where both are rounded up
+        while (num1 + num2 > 100) {
+            if (num1 > num2)
+                num1 -= 0.1;
+            if (num2 > num1)
+                num2 -= 0.1;
+        }
+        return [num1, num2];
+    }
+    return {
+        Statistics: Statistics
+    };
+}());
+</script>
+<script type="text/javascript">
+window.util = function () {
+    function map(elems, func) {
+        var ret = [];
+        for (var i = 0, len = elems.length; i < len; i++) {
+            ret[i] = func(elems[i]);
+        }
+        return ret;
+    }
+    function filter(elems, predicate) {
+        var ret = [];
+        for (var i = 0, len = elems.length; i < len; i++) {
+            if (predicate(elems[i]))
+                ret.push(elems[i]);
+        }
+        return ret;
+    }
+    function all(elems) {
+        for (var i = 0, len = elems.length; i < len; i++) {
+            if (!elems[i])
+                return false;
+        }
+        return true;
+    }
+    function any(elems) {
+        for (var i = 0, len = elems.length; i < len; i++) {
+            if (elems[i])
+                return elems[i];
+        }
+        return false;
+    }
+    function contains(elems, e) {
+        for (var i = 0, len = elems.length; i < len; i++) {
+            if (elems[i] == e)
+                return true;
+        }
+        return false;
+    }
+    function last(items) {
+        return items[items.length-1];
+    }
+    function unescape(string) {
+        return string.replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&');
+    }
+    function escape(string) {
+        return string.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    }
+    function normalize(string) {
+        return string.toLowerCase().replace(/ /g, '').replace(/_/g, '');
+    }
+    function regexpEscape(string) {
+        return string.replace(/[-[\]{}()+?*.,\\^$|#]/g, "\\$&");
+    }
+    function Matcher(pattern) {
+        pattern = regexpEscape(normalize(pattern));
+        var rePattern = '^' + pattern.replace(/\\\?/g, '.').replace(/\\\*/g, '[\\s\\S]*') + '$';
+        var regexp = new RegExp(rePattern);
+        function matches(string) {
+            return regexp.test(normalize(string));
+        }
+        return {
+            matches: matches,
+            matchesAny: function (strings) {
+                for (var i = 0, len = strings.length; i < len; i++)
+                    if (matches(strings[i]))
+                        return true;
+                return false;
+            }
+        };
+    }
+    function formatParentName(item) {
+        var parentName = item.fullName.slice(0, item.fullName.length - item.name.length);
+        return parentName.replace(/\./g, ' . ');
+    }
+    function timeFromDate(date) {
+        if (!date)
+            return 'N/A';
+        return formatTime(date.getHours(), date.getMinutes(),
+                          date.getSeconds(), date.getMilliseconds());
+    }
+    function dateFromDate(date) {
+        if (!date)
+            return 'N/A';
+        return padTo(date.getFullYear(), 4) +
+               padTo(date.getMonth() + 1, 2) +
+               padTo(date.getDate(), 2);
+    }
+    function dateTimeFromDate(date) {
+        if (!date)
+            return 'N/A';
+        return dateFromDate(date) + ' ' + timeFromDate(date);
+    }
+    function formatTime(hours, minutes, seconds, milliseconds) {
+        return padTo(hours, 2) + ':' +
+               padTo(minutes, 2) + ':' +
+               padTo(seconds, 2) + '.' +
+               padTo(milliseconds, 3);
+    }
+    function formatElapsed(elapsed) {
+        var millis = elapsed;
+        var hours = Math.floor(millis / (60 * 60 * 1000));
+        millis -= hours * 60 * 60 * 1000;
+        var minutes = Math.floor(millis / (60 * 1000));
+        millis -= minutes * 60 * 1000;
+        var seconds = Math.floor(millis / 1000);
+        millis -= seconds * 1000;
+        return formatTime(hours, minutes, seconds, millis);
+    }
+    function padTo(number, len) {
+        var numString = number + "";
+        while (numString.length < len) numString = "0" + numString;
+        return numString;
+    }
+    function timestamp(millis) {
+        // used also by tools that do not set window.output.baseMillis
+        var base = window.output ? window.output.baseMillis : 0;
+        return new Date(base + millis);
+    }
+    function createGeneratedAgoString(generatedMillis) {
+        generatedMillis = timestamp(generatedMillis);
+        function timeString(time, shortUnit) {
+            var unit = {y: 'year', d: 'day', h: 'hour', m: 'minute',
+                        s: 'second'}[shortUnit];
+            var end = time == 1 ? ' ' : 's ';
+            return time + ' ' + unit + end;
+        }
+        function compensateLeapYears(days, years) {
+            // Not a perfect algorithm but ought to be enough
+            return days - Math.floor(years / 4);
+        }
+        var generated = Math.round(generatedMillis / 1000);
+        var current = Math.round(new Date().getTime() / 1000);
+        var elapsed = current - generated;
+        var prefix = '';
+        if (elapsed < 0) {
+            prefix = '- ';
+            elapsed = Math.abs(elapsed);
+        }
+        var secs  = elapsed % 60;
+        var mins  = Math.floor(elapsed / 60) % 60;
+        var hours = Math.floor(elapsed / (60*60)) % 24;
+        var days  = Math.floor(elapsed / (60*60*24)) % 365;
+        var years = Math.floor(elapsed / (60*60*24*365));
+        if (years) {
+            days = compensateLeapYears(days, years);
+            return prefix + timeString(years, 'y') + timeString(days, 'd');
+        } else if (days) {
+            return prefix + timeString(days, 'd') + timeString(hours, 'h');
+        } else if (hours) {
+            return prefix + timeString(hours, 'h') + timeString(mins, 'm');
+        } else if (mins) {
+            return prefix + timeString(mins, 'm') + timeString(secs, 's');
+        } else {
+            return prefix + timeString(secs, 's');
+        }
+    }
+    function parseQueryString(query) {
+        var result = {};
+        if (!query)
+            return result;
+        var params = query.split('&');
+        var parts;
+        function decode(item) {
+            return decodeURIComponent(item.replace('+', ' '));
+        }
+        for (var i = 0, len = params.length; i < len; i++) {
+            parts = params[i].split('=');
+            result[decode(parts.shift())] = decode(parts.join('='));
+        }
+        return result;
+    }
+    return {
+        map: map,
+        filter: filter,
+        all: all,
+        any: any,
+        contains: contains,
+        last: last,
+        escape: escape,
+        unescape: unescape,
+        normalize: normalize,
+        regexpEscape: regexpEscape,
+        Matcher: Matcher,
+        formatParentName: formatParentName,
+        timeFromDate: timeFromDate,
+        dateFromDate: dateFromDate,
+        dateTimeFromDate: dateTimeFromDate,
+        formatElapsed: formatElapsed,
+        timestamp: timestamp,
+        createGeneratedAgoString: createGeneratedAgoString,
+        parseQueryString: parseQueryString
+    };
+}();
+</script>
+<script type="text/javascript">
+window.testdata = function () {
+    var elementsById = {};
+    var idCounter = 0;
+    var _statistics = null;
+    var LEVELS = ['TRACE', 'DEBUG', 'INFO', 'WARN', 'ERROR', 'FAIL'];
+    var STATUSES = ['FAIL', 'PASS', 'NOT_RUN'];
+    var KEYWORDS = ['KEYWORD', 'SETUP', 'TEARDOWN', 'FOR', 'VAR'];
+    function addElement(elem) {
+        if (!elem.id)
+            elem.id = uniqueId();
+        elementsById[elem.id] = elem;
+        return elem;
+    }
+    function uniqueId() {
+        idCounter++;
+        return 'element-id-' + idCounter;
+    }
+    function times(stats) {
+        var startMillis = stats[1];
+        var elapsed = stats[2];
+        if (startMillis === null)
+            return [null, null, elapsed];
+        return [util.timestamp(startMillis),
+                util.timestamp(startMillis + elapsed),
+                elapsed];
+    }
+    function message(element, strings) {
+        return addElement(model.Message(LEVELS[element[1]],
+                                        util.timestamp(element[0]),
+                                        strings.get(element[2]),
+                                        strings.get(element[3])));
+    }
+    function parseStatus(stats) {
+        return STATUSES[stats[0]];
+    }
+    function childCreator(parent, childType) {
+        return function (elem, strings, index) {
+            return addElement(childType(parent, elem, strings, index));
+        };
+    }
+    function createKeyword(parent, element, strings, index) {
+        var kw = model.Keyword({
+            parent: parent,
+            type: KEYWORDS[element[0]],
+            id: 'k' + (index + 1),
+            name: strings.get(element[1]),
+            libname: strings.get(element[2]),
+            timeout: strings.get(element[3]),
+            args: strings.get(element[5]),
+            assign: strings.get(element[6]),
+            tags: strings.get(element[7]),
+            doc: function () {
+                var doc = strings.get(element[4]);
+                this.doc = function () { return doc; };
+                return doc;
+            },
+            status: parseStatus(element[8], strings),
+            times: model.Times(times(element[8])),
+            isChildrenLoaded: typeof(element[9]) !== 'number'
+        });
+        lazyPopulateKeywordsFromFile(kw, element[9], strings);
+        kw.populateMessages(Populator(element[10], strings, message));
+        return kw;
+    }
+    function lazyPopulateKeywordsFromFile(parent, modelOrIndex, strings) {
+        var model, index, populator;
+        var creator = childCreator(parent, createKeyword);
+        if (parent.isChildrenLoaded) {
+            model = modelOrIndex;
+            populator = Populator(model, strings, creator);
+        } else {
+            index = modelOrIndex;
+            parent.childFileName = window.settings['splitLogBase'] + '-' + index + '.js';
+            populator = SplitLogPopulator(index, creator);
+        }
+        parent.populateKeywords(populator);
+    }
+    function tags(taglist, strings) {
+        return util.map(taglist, strings.get);
+    }
+    function createTest(parent, element, strings, index) {
+        var statusElement = element[5];
+        var test = model.Test({
+            parent: parent,
+            id: 't' + (index + 1),
+            name: strings.get(element[0]),
+            doc: function () {
+                var doc = strings.get(element[3]);
+                this.doc = function () { return doc; };
+                return doc;
+            },
+            timeout: strings.get(element[1]),
+            isCritical: element[2],
+            status: parseStatus(statusElement),
+            message: function () {
+                var msg = createMessage(statusElement, strings);
+                this.message = function () { return msg; };
+                return msg;
+            },
+            times: model.Times(times(statusElement)),
+            tags: tags(element[4], strings),
+            isChildrenLoaded: typeof(element[6]) !== 'number'
+        });
+        lazyPopulateKeywordsFromFile(test, element[6], strings);
+        return test;
+    }
+    function createMessage(statusElement, strings) {
+        return statusElement.length == 4 ? strings.get(statusElement[3]) : '';
+    }
+    function createSuite(parent, element, strings, index) {
+        var statusElement = element[5];
+        var suite = model.Suite({
+            parent: parent,
+            id: 's' + ((index || 0) + 1),
+            name: strings.get(element[0]),
+            source: strings.get(element[1]),
+            relativeSource: strings.get(element[2]),
+            doc: function () {
+                var doc = strings.get(element[3]);
+                this.doc = function () { return doc; };
+                return doc;
+            },
+            status: parseStatus(statusElement),
+            message: function () {
+                var msg = createMessage(statusElement, strings);
+                this.message = function () { return msg; };
+                return msg;
+            },
+            times: model.Times(times(statusElement)),
+            statistics: suiteStats(util.last(element)),
+            metadata: parseMetadata(element[4], strings)
+        });
+        suite.populateKeywords(Populator(element[8], strings, childCreator(suite, createKeyword)));
+        suite.populateTests(Populator(element[7], strings, childCreator(suite, createTest)));
+        suite.populateSuites(Populator(element[6], strings, childCreator(suite, createSuite)));
+        return suite;
+    }
+    function parseMetadata(data, strings) {
+        var metadata = [];
+        for (var i=0; i<data.length; i+=2) {
+            metadata.push([strings.get(data[i]), strings.get(data[i+1])]);
+        }
+        return metadata;
+    }
+    function suiteStats(stats) {
+        return {
+            total: stats[0],
+            totalPassed: stats[1],
+            totalFailed: stats[0] - stats[1],
+            critical: stats[2],
+            criticalPassed: stats[3],
+            criticalFailed: stats[2] - stats[3]
+        };
+    }
+    function Populator(items, strings, creator) {
+        return {
+            numberOfItems: function () {
+                return items.length;
+            },
+            creator: function (index) {
+                return creator(items[index], strings, index);
+            }
+        };
+    }
+    function SplitLogPopulator(structureIndex, creator) {
+        return {
+            numberOfItems: function () {
+                return window['keywords'+structureIndex].length;
+            },
+            creator: function (index) {
+                return creator(window['keywords'+structureIndex][index],
+                               StringStore(window['strings'+structureIndex]),
+                               index);
+            }
+        };
+    }
+    function suite() {
+        var elem = window.output.suite;
+        if (elementsById[elem.id])
+            return elem;
+        var root = addElement(createSuite(null, elem, StringStore(window.output.strings)));
+        window.output.suite = root;
+        return root;
+    }
+    function findLoaded(id) {
+        return elementsById[id];
+    }
+    function ensureLoaded(id, callback) {
+        var ids = id.split('-');
+        var root = suite();
+        ids.shift();
+        loadItems(ids, root, [root.id], callback);
+    }
+    function loadItems(ids, current, result, callback) {
+        if (!ids.length) {
+            callback(result);
+            return;
+        }
+        current.callWhenChildrenReady(function () {
+            var id = ids.shift();
+            var type = id[0];
+            var index = parseInt(id.substring(1)) - 1;
+            var item = selectFrom(current, type, index);
+            result.push(item.id);
+            loadItems(ids, item, result, callback);
+        });
+    }
+    function selectFrom(element, type, index) {
+        if (type === 'k') {
+            return element.keywords()[index];
+        } else if (type === 't') {
+            return element.tests()[index];
+        } else {
+            return element.suites()[index];
+        }
+    }
+    function errorIterator() {
+        return {
+            next: function () {
+                return message(window.output.errors.shift(),
+                               StringStore(window.output.strings));
+            },
+            hasNext: function () {
+                return window.output.errors.length > 0;
+            }
+        };
+    }
+    function statistics() {
+        if (!_statistics) {
+            var statData = window.output.stats;
+            _statistics = stats.Statistics(statData[0], statData[1], statData[2]);
+        }
+        return _statistics;
+    }
+    function StringStore(strings) {
+        function getText(id) {
+            var text = strings[id];
+            if (!text)
+                return '';
+            if (text[0] == '*')
+                return text.substring(1);
+            var extracted = extract(text);
+            strings[id] = '*' + extracted;
+            return extracted;
+        }
+        function extract(text) {
+            var decoded = JXG.Util.Base64.decodeAsArray(text);
+            var extracted = (new JXG.Util.Unzip(decoded)).unzip()[0][0];
+            return JXG.Util.UTF8.decode(extracted);
+        }
+        function get(id) {
+            if (id === null) return null;
+            return getText(id);
+        }
+        return {get: get};
+    }
+    return {
+        suite: suite,
+        errorIterator: errorIterator,
+        findLoaded: findLoaded,
+        ensureLoaded: ensureLoaded,
+        statistics: statistics,
+        StringStore: StringStore,  // exposed for tests
+        LEVELS: LEVELS
+    };
+}();
+</script>
+<script type="text/javascript">
+function removeJavaScriptDisabledWarning() {
+    // Not using jQuery here for maximum speed
+    document.getElementById('javascript-disabled').style.display = 'none';
+}
+function addJavaScriptDisabledWarning(error) {
+    if (window.console)
+        console.error('Opening failed: ' + error.name + ': ' + error.message);
+    document.getElementById('javascript-disabled').style.display = 'block';
+}
+function initLayout(suiteName, type) {
+    parseTemplates();
+    setTitle(suiteName, type);
+    addHeader();
+    addReportOrLogLink(type);
+}
+function parseTemplates() {
+    $('script[type="text/x-jquery-tmpl"]').map(function (idx, elem) {
+        $.template(elem.id, elem.text);
+    });
+}
+function setTitle(suiteName, type) {
+    var givenTitle = window.settings.title;
+    var title = givenTitle ? givenTitle : suiteName + " Test " + type;
+    document.title = util.unescape(title);
+}
+function addHeader() {
+    $.tmpl('<h1>${title}</h1>' +
+           '<div id="generated">' +
+             '<span>Generated<br>${generated}</span><br>' +
+             '<span id="generated-ago">${ago} ago</span>' +
+           '</div>' +
+           '<div id="top-right-header">' +
+             '<div id="report-or-log-link"><a href="#"></a></div>' +
+           '</div>', {
+        generated: window.output.generatedTimestamp,
+        ago: util.createGeneratedAgoString(window.output.generatedMillis),
+        title: document.title
+    }).appendTo($('#header'));
+}
+function addReportOrLogLink(myType) {
+    var url;
+    var text;
+    var container = $('#report-or-log-link');
+    if (myType == 'Report') {
+        url = window.settings.logURL;
+        text = 'LOG';
+    } else {
+        url = window.settings.reportURL;
+        text = 'REPORT';
+    }
+    if (url) {
+        container.find('a').attr('href', url);
+        container.find('a').text(text);
+    } else {
+        container.remove();
+    }
+}
+function addStatistics() {
+    var statHeaders =
+        '<th class="stats-col-stat">Total</th>' +
+        '<th class="stats-col-stat">Pass</th>' +
+        '<th class="stats-col-stat">Fail</th>' +
+        '<th class="stats-col-elapsed">Elapsed</th>' +
+        '<th class="stats-col-graph">Pass / Fail</th>';
+    var statTable =
+        '<h2>Test Statistics</h2>' +
+        '<table class="statistics" id="total-stats"><thead><tr>' +
+        '<th class="stats-col-name">Total Statistics</th>' + statHeaders +
+        '</tr></thead></table>' +
+        '<table class="statistics" id="tag-stats"><thead><tr>' +
+        '<th class="stats-col-name">Statistics by Tag</th>' + statHeaders +
+        '</tr></thead></table>' +
+        '<table class="statistics" id="suite-stats"><thead><tr>' +
+        '<th class="stats-col-name">Statistics by Suite</th>' + statHeaders +
+        '</tr></thead></table>';
+    $(statTable).appendTo('#statistics-container');
+    util.map(['total', 'tag', 'suite'], addStatTable);
+    addTooltipsToElapsedTimes();
+    enableStatisticsSorter();
+}
+function addTooltipsToElapsedTimes() {
+    $('.stats-col-elapsed').attr('title',
+        'Total execution time of these test cases. ' +
+        'Excludes suite setups and teardowns.');
+    $('#suite-stats').find('.stats-col-elapsed').attr('title',
+        'Total execution time of this test suite.');
+}
+function enableStatisticsSorter() {
+    $.tablesorter.addParser({
+        id: 'statName',
+        type: 'numeric',
+        is: function(s) {
+            return false;  // do not auto-detect
+        },
+        format: function(string, table, cell, cellIndex) {
+            // Rows have class in format 'row-<index>'.
+            var index = $(cell).parent().attr('class').substring(4);
+            return parseInt(index);
+        }
+    });
+    $(".statistics").tablesorter({
+        sortInitialOrder: 'desc',
+        headers: {0: {sorter:'statName', sortInitialOrder: 'asc'},
+                  5: {sorter: false}}
+    });
+}
+function addStatTable(tableName) {
+    var stats = window.testdata.statistics()[tableName];
+    if (tableName == 'tag' && stats.length == 0) {
+        renderNoTagStatTable();
+    } else {
+        renderStatTable(tableName, stats);
+    }
+}
+function renderNoTagStatTable() {
+    $('<tbody><tr class="row-0">' +
+        '<td class="stats-col-name">No Tags</td>' +
+        '<td class="stats-col-stat"></td>' +
+        '<td class="stats-col-stat"></td>' +
+        '<td class="stats-col-stat"></td>' +
+        '<td class="stats-col-elapsed"></td>' +
+        '<td class="stats-col-graph">' +
+          '<div class="empty-graph"></div>' +
+        '</td>' +
+      '</tr></tbody>').appendTo('#tag-stats');
+}
+function renderStatTable(tableName, stats) {
+    var template = tableName + 'StatisticsRowTemplate';
+    var tbody = $('<tbody></tbody>');
+    for (var i = 0, len = stats.length; i < len; i++) {
+        $.tmpl(template, stats[i], {index: i}).appendTo(tbody);
+    }
+    tbody.appendTo('#' + tableName + '-stats');
+}
+$.template('statColumnsTemplate',
+    '<td class="stats-col-stat">${total}</td>' +
+    '<td class="stats-col-stat">${pass}</td>' +
+    '<td class="stats-col-stat">${fail}</td>' +
+    '<td class="stats-col-elapsed">${elapsed}</td>' +
+    '<td class="stats-col-graph">' +
+      '{{if total}}' +
+      '<div class="graph">' +
+        '<div class="pass-bar" style="width: ${passWidth}%" title="${passPercent}%"></div>' +
+        '<div class="fail-bar" style="width: ${failWidth}%" title="${failPercent}%"></div>' +
+      '</div>' +
+      '{{else}}' +
+      '<div class="empty-graph"></div>' +
+      '{{/if}}' +
+    '</td>'
+);
+$.template('suiteStatusMessageTemplate',
+    '${critical} critical test, ' +
+    '${criticalPassed} passed, ' +
+    '<span class="{{if criticalFailed}}fail{{else}}pass{{/if}}">${criticalFailed} failed</span><br>' +
+    '${total} test total, ' +
+    '${totalPassed} passed, ' +
+    '<span class="{{if totalFailed}}fail{{else}}pass{{/if}}">${totalFailed} failed</span>'
+);
+// For complete cross-browser experience..
+// http://www.quirksmode.org/js/events_order.html
+function stopPropagation(event) {
+    var event = event || window.event;
+    event.cancelBubble = true;
+    if (event.stopPropagation)
+        event.stopPropagation();
+}
+</script>
+<script type="text/javascript">
+storage = function () {
+    var prefix = 'robot-framework-';
+    function init(user) {
+        prefix += user + '-';
+    }
+    function get(name, defaultValue) {
+        if (!localStorage)
+            return defaultValue;
+        var value = localStorage[prefix + name];
+        if (typeof value === 'undefined')
+            return defaultValue;
+        return value;
+    }
+    function set(name, value) {
+        if (localStorage)
+            localStorage[prefix + name] = value;
+    }
+    return {init: init, get: get, set: set};
+}();
+</script>
+<script type="text/javascript">
+window.output = {};
+</script>
+<script type="text/javascript">
+window.output["suite"] = [1,2,3,0,[],[1,0,262723],[[4,5,6,7,[],[1,55,3632],[],[[8,0,1,9,[10],[1,1559,157],[]],[11,0,1,12,[10],[1,1718,305],[]],[13,0,1,14,[10],[1,2024,238],[]],[15,0,1,16,[10],[1,2263,168],[]],[17,0,1,18,[10],[1,2432,643],[]],[19,0,1,20,[10],[1,3076,526],[]],[21,0,1,22,[10],[1,3603,83],[]]],[],[7,7,7,7]],[23,24,25,26,[],[1,3702,73604],[],[[27,0,1,28,[10],[1,3733,40050],[]],[29,0,1,30,[10],[1,43785,33520],[]]],[],[2,2,2,2]],[31,32,33,34,[],[1,77309,62149],[],[[35,0,1,36,[10],[1,77322,15388],[]],[37,0,1,38,[10],[1,92710,15960],[]],[39,0,1,40,[10],[1,108670,30788],[]]],[],[3,3,3,3]],[41,42,43,44,[],[1,139460,63729],[],[[45,0,1,46,[10],[1,139469,63719],[]]],[],[1,1,1,1]],[47,48,49,50,[],[1,203191,20796],[],[[51,0,1,52,[10],[1,204737,298],[]],[53,0,1,54,[10],[1,205036,14459],[]],[55,0,1,56,[10],[1,219497,1067],[]],[57,0,1,58,[10],[1,220565,966],[]],[59,0,1,60,[10],[1,221531,1208],[]],[61,0,1,62,[10],[1,222739,1246],[]]],[],[6,6,6,6]],[63,64,65,66,[],[1,223989,38706],[],[[67,0,1,68,[69],[1,224027,38054],[]],[70,0,1,71,[69],[1,262082,610],[]]],[],[2,2,2,2]]],[],[],[21,21,21,21]];
+</script>
+<script type="text/javascript">
+window.output["strings"] = [];
+</script>
+<script type="text/javascript">
+window.output["strings"] = window.output["strings"].concat(["*","*Acceptance","*/home/guillaume/code/workspaceElPaasov14/autosleep/acceptance","*acceptance","*1 Service Broker Lifecycle","*/home/guillaume/code/workspaceElPaasov14/autosleep/acceptance/1_service_broker_lifecycle.robot","*acceptance/1_service_broker_lifecycle.robot","*<p>Test basic service broker lifecycle\x3c/p>","*0) Prepare","*<p>Clean service bindings and instance if exist\x3c/p>","*Service broker","*1) create service broker","*<p>Create a service broker\x3c/p>","*2) create service instance","*<p>Create a service instance\x3c/p>","*3) bind","*<p>Bind static to base service instance\x3c/p>","*4) unbind","*<p>Unbind application\x3c/p>","*5) delete service instance","*<p>Delete service instance\x3c/p>","*6) delete service broker","*<p>Delete service broker\x3c/p>","*2 Inactivity Detection","*/home/guillaume/code/workspaceElPaasov14/autosleep/acceptance/2_inactivity_detection.robot","*acceptance/2_inactivity_detection.robot","*<p>Test if application inactivity is detected\x3c/p>","*1) Detect inactivity after http activity","*<p>Check that app are stopped PT20S after their last http activity\x3c/p>","*2) Detect inactivity after a restart","*<p>Check that app are stopped PT20S after their last reboot\x3c/p>","*3 App Autoenrollment","*/home/guillaume/code/workspaceElPaasov14/autosleep/acceptance/3_app_autoenrollment.robot","*acceptance/3_app_autoenrollment.robot","*<p>Test apps get automatically bound in standard enrollment mode\x3c/p>","*1) Eligible app get automatically enrolled","*<p>Check that app is automatically bound by service instance\x3c/p>","*2) Excluded app don't get automatically enrolled","*<p>Check that no application is bound by the service instance\x3c/p>","*3) Service does not bind stopped applications","*<p>Check that stopped applications are not bound\x3c/p>","*4 Opt-Outs","*/home/guillaume/code/workspaceElPaasov14/autosleep/acceptance/4_opt-outs.robot","*acceptance/4_opt-outs.robot","*<p>Test users can permanently opt out in standard enrollment mode\x3c/p>","*1) Unbound application should not be put to sleep","*<p>Check that app are still started PT20S after their last http activity\x3c/p>","*5 Forced Enrollment","*/home/guillaume/code/workspaceElPaasov14/autosleep/acceptance/5_forced_enrollment.robot","*acceptance/5_forced_enrollment.robot","*<p>Users can only transiently opt-out\x3c/p>","*1) No forced auto-enrollment without secret","*<p>Check that we can not create a service with auto-enrollment=forced option without providing a secret\x3c/p>","*2) app opt-opt outs are transient","*<p>In forced auto-enrollment, check that we can not permamently unbind an app from a service: Applications will be automatically rebound\x3c/p>","*3) can not delete autosleep service instance","*<p>Check that during forced auto-enrollment mode, a service instance can't be deleted to escape from autoenrolling apps within the space\x3c/p>","*4) Auto-enrollment mode can not change with wrong secret","*<p>Check that the auto-enrollment option of a service can not be updated without providing the right secret\x3c/p>","*5) Auto-enrollment mode can change with right secret","*<p>Check that the auto-enrollment option can be changed if the right secret is provided\x3c/p>","*6) Auto-enrollment mode can change with admin secret","*<p>Check that the auto-enrollment option can be changed if the admin secret is provided\x3c/p>","*6 Autowakeup Wildcard Route","*/home/guillaume/code/workspaceElPaasov14/autosleep/acceptance/6_autowakeup_wildcard_route.robot","*acceptance/6_autowakeup_wildcard_route.robot","*<p>Test the autowakeup feature based on wildcard routes\x3c/p>","*1) Incoming traffic will trigger app restart a sleeping appl","eNptkEFOxDAMRfec4i9BAhUNYhdVQlxhLpCmprEmTSLHoeL2uGVAArGJrdj/2f4unsaXrmX1ygFCTb0o1GJzg9VuXB3dNJ4jt+MXmWi2tGAiSM8oGR5rT8oPnE2dAzV4I27+Qr3i1isSeVOe7nZZ6yEYwg3T6IZq/J7sSTy+RgoXaLR+X+s1EULTUivNmD4ObEtE9Shcl7WS7cA5lJXzAhX/xsENRvyL1a2gevEpUUKw0LBxSpiKRtPxspDgywAjHjfVRPg5697aNZauJu5tH0YiRf6fZWvYHmiUFXOXvfvb3WOoUCB+JzPv+fHpF2gwRz4BcD+QHQ==","*Autowakeup","*2) Incoming traffic on other unbound stopped app doesn't trigger a restart","*<p>Check that orphan traffic received on non-enrolled apps does not trigger a restart\x3c/p>"]);
+</script>
+<script type="text/javascript">
+window.output["generatedTimestamp"] = "20160824 18:16:16 GMT +02:00";
+</script>
+<script type="text/javascript">
+window.output["stats"] = [[{"elapsed":"00:04:19","fail":0,"label":"Critical Tests","pass":21},{"elapsed":"00:04:19","fail":0,"label":"All Tests","pass":21}],[{"elapsed":"00:00:39","fail":0,"label":"Autowakeup","pass":2},{"elapsed":"00:03:41","fail":0,"label":"Service broker","pass":19}],[{"elapsed":"00:04:23","fail":0,"id":"s1","label":"Acceptance","name":"Acceptance","pass":21},{"elapsed":"00:00:04","fail":0,"id":"s1-s1","label":"Acceptance.1 Service Broker Lifecycle","name":"1 Service Broker Lifecycle","pass":7},{"elapsed":"00:01:14","fail":0,"id":"s1-s2","label":"Acceptance.2 Inactivity Detection","name":"2 Inactivity Detection","pass":2},{"elapsed":"00:01:02","fail":0,"id":"s1-s3","label":"Acceptance.3 App Autoenrollment","name":"3 App Autoenrollment","pass":3},{"elapsed":"00:01:04","fail":0,"id":"s1-s4","label":"Acceptance.4 Opt-Outs","name":"4 Opt-Outs","pass":1},{"elapsed":"00:00:21","fail":0,"id":"s1-s5","label":"Acceptance.5 Forced Enrollment","name":"5 Forced Enrollment","pass":6},{"elapsed":"00:00:39","fail":0,"id":"s1-s6","label":"Acceptance.6 Autowakeup Wildcard Route","name":"6 Autowakeup Wildcard Route","pass":2}]];
+</script>
+<script type="text/javascript">
+window.output["generatedMillis"] = 262829;
+</script>
+<script type="text/javascript">
+window.output["baseMillis"] = 1472055113171;
+</script>
+<script type="text/javascript">
+window.settings = {"background":{"fail":"#f66","nonCriticalFail":"#9e9","pass":"#9e9"},"logURL":"log.html","title":""};
+</script>
+<title></title>
+</head>
+<body>
+<div id="javascript-disabled">
+  <h1>Opening Robot Framework report failed</h1>
+  <ul>
+    <li>Verify that you have <b>JavaScript enabled</b> in your browser.</li>
+    <li>Make sure you are using a <b>modern enough browser</b>. Firefox 3.5, IE 8, or equivalent is required, newer browsers are recommended.</li>
+    <li>Check are there messages in your browser's <b>JavaScript error log</b>. Please report the problem if you suspect you have encountered a bug.</li>
+  </ul>
+</div>
+<script type="text/javascript">removeJavaScriptDisabledWarning();</script>
+
+<div id="header"></div>
+<div id="statistics-container"></div>
+<div id="test-details-container"></div>
+
+<script type="text/javascript">
+$(document).ready(function () {
+    try {
+        var topsuite = window.testdata.suite();
+    } catch (error) {
+        addJavaScriptDisabledWarning(error);
+        return;
+    }
+    setBackground(topsuite);
+    initLayout(topsuite.name, 'Report');
+    storage.init('report');
+    addSummary(topsuite);
+    addStatistics();
+    addDetails();
+    window.prevLocationHash = '';
+    window.onhashchange = showDetailsByHash;
+});
+
+function setBackground(topsuite) {
+    var color;
+    if (topsuite.criticalFailed)
+        color = window.settings.background.fail;
+    else if (topsuite.totalFailed)
+        color = window.settings.background.nonCriticalFail;
+    else
+        color = window.settings.background.pass;
+    $('body').css('background-color', color);
+}
+
+function addSummary(topsuite) {
+    var opts = {logURL: window.settings.logURL};
+    $.tmpl('summaryTableTemplate', topsuite, opts).insertAfter($('#header'));
+}
+
+function addDetails() {
+    addCustomSortersForDetails();
+    if (window.location.hash)
+        showDetailsByHash();
+    else
+        renderTotalSelector();
+}
+
+function addCustomSortersForDetails() {
+    $.tablesorter.addParser({
+        id: 'criticality',
+        type: 'numeric',
+        is: function(s) {
+            return false;  // do not auto-detect
+        },
+        format: function(s) {
+            return s === 'yes' ? 0 : 1;
+        }
+    });
+    $.tablesorter.addParser({
+        id: 'times',
+        type: 'text',
+        is: function(s) {
+            return false;  // do not auto-detect
+        },
+        format: function(s) {
+            return s.substring(0, 21);  // return only start time
+        }
+    });
+}
+
+function showDetailsByHash() {
+    // Cannot use window.location.hash because Firefox incorrectly decodes it:
+    // http://stackoverflow.com/questions/1703552/encoding-of-window-location-hash
+    var hash = window.location.href.split('#').slice(1).join('#');
+    if (!hash || hash == window.prevLocationHash)
+        return;
+    var parts = hash.split('?');
+    var name = parts.shift();
+    var query = parts.join('?');
+    if (name == 'search') {
+        var params = util.parseQueryString(query);
+        searchExecuted(params.suite || '', params.test || '',
+                       params.include || '', params.exclude || '');
+        return
+    }
+    query = decodeURIComponent(query);
+    var action = {'totals': totalDetailSelected,
+                  'tags':   tagDetailSelected,
+                  'suites': suiteDetailSelected}[name];
+    if (action)
+        action(query);
+}
+
+function totalDetailSelected(name) {
+    renderTotalSelector(name);
+    if (name) {
+        renderTotalDetails(name);
+        updatePrintSelector(name == 'critical' ? 'Critical Tests' : 'All Tests');
+    }
+    scrollToSelector('totals', name);
+}
+
+function renderTotalSelector(name) {
+    var args = {linkTarget: (name) ? 'totals?'+name : 'totals',
+                totalTabStatus: 'detail-tab-selected'};
+    renderSelector(args, 'totalDetailsSelectorTemplate', {selected: name});
+}
+
+function renderTotalDetails(name) {
+    var index = (name == 'critical') ? 0 : 1;
+    var stat = window.testdata.statistics().total[index];
+    var tests = getTotalTests(name);
+    stat.totalTime = calculateTotalTime(tests);
+    $.tmpl('tagOrTotalDetailsTemplate', stat).appendTo('#details-header');
+    drawTestDetailsTable(tests, true);
+}
+
+function updatePrintSelector(name, info) {
+    if (info)
+        name += ' (' + info + ')';
+    $('#print-selector').html(name);
+}
+
+function tagDetailSelected(name) {
+    renderTagSelector(name);
+    if (name) {
+        var tag = findTag(name);
+        if (tag) {
+            renderTagDetails(tag);
+            updatePrintSelector(name, tag.info);
+        }
+    }
+    scrollToSelector('tags', name);
+}
+
+function findTag(name) {
+    var tags = window.testdata.statistics().tag;
+    for (var i = 0, len = tags.length; i < len; i++) {
+        if (tags[i].label == name)
+            return tags[i];
+    }
+    return null;
+}
+
+function renderTagSelector(name) {
+    var args = {linkTarget: (name) ? 'tags?'+name : 'tags',
+                tagTabStatus: 'detail-tab-selected'};
+    var stats = {tags: window.testdata.statistics().tag, selected: name};
+    renderSelector(args, 'tagDetailsSelectorTemplate', stats);
+}
+
+function renderTagDetails(tag) {
+    var tests = getTestsHavingTag(tag);
+    tag.totalTime = calculateTotalTime(tests);
+    $.tmpl('tagOrTotalDetailsTemplate', tag).appendTo('#details-header');
+    drawTestDetailsTable(tests, true);
+}
+
+function suiteDetailSelected(id) {
+    renderSuiteSelector(id);
+    if (id)
+        renderSuiteDetails(id);
+    scrollToSelector('suites', id);
+}
+
+function renderSuiteSelector(id) {
+    var args = {linkTarget: (id) ? 'suites?'+id : 'suites',
+                suiteTabStatus: 'detail-tab-selected'};
+    var stats = {suites: window.testdata.statistics().suite,
+                 selected: id};
+    renderSelector(args, 'suiteDetailsSelectorTemplate', stats);
+}
+
+function renderSuiteDetails(id) {
+    window.testdata.ensureLoaded(id, function (ids) {
+        var suite = window.testdata.findLoaded(id);
+        var opts = {logURL: window.settings.logURL};
+        $.tmpl('suiteDetailsTemplate', suite, opts).appendTo('#details-header');
+        drawTestDetailsTable(suite.allTests(), false);
+        updatePrintSelector(suite.fullName);
+    });
+}
+
+function searchExecuted(suite, test, include, exclude) {
+    renderSearchSelector(suite, test, include, exclude);
+    if (suite || test || include || exclude) {
+        renderSearchDetails(suite, test, include, exclude);
+        scrollToSelector('search' +
+                         '?suite=' + encodeURIComponent(suite) +
+                         '&test=' + encodeURIComponent(test) +
+                         '&include=' + encodeURIComponent(include) +
+                         '&exclude=' + encodeURIComponent(exclude));
+    } else {
+        scrollToSelector('search');
+    }
+}
+
+function renderSearchSelector(suite, test, include, exclude) {
+    var args = {linkTarget: (suite || test || include || exclude) ?
+                            ('search?suite=' + suite + '&test=' + test + '&include=' + include + '&exclude=' + exclude) :
+                            'search',
+                searchTabStatus: 'detail-tab-selected'};
+    var search = {suite: suite, test: test, include: include, exclude: exclude};
+    renderSelector(args, 'searchSelectorTemplate', search);
+}
+
+function renderSearchDetails(suite, test, include, exclude) {
+    var tests = searchTests(util.escape(suite), util.escape(test),
+                            util.escape(include), util.escape(exclude));
+    var passed = calculatePassed(tests);
+    var stats = {total: tests.length,
+                 pass: passed,
+                 fail: tests.length - passed,
+                 totalTime: calculateTotalTime(tests)};
+    $.tmpl('tagOrTotalDetailsTemplate', stats).appendTo('#details-header');
+    drawTestDetailsTable(tests, true);
+}
+
+function searchTests(suitePattern, testPattern, includePattern, excludePattern) {
+    var tests;
+    if (suitePattern)
+        tests = window.testdata.suite().searchTestsInSuite(suitePattern);
+    else
+        tests = window.testdata.suite().allTests();
+    return util.filter(tests, function (test) {
+        if (testPattern && !test.matchesNamePattern(testPattern))
+            return false;
+        if (includePattern && !test.matchesTagPattern(includePattern))
+            return false;
+        return !(excludePattern && test.matchesTagPattern(excludePattern));
+    });
+}
+
+function scrollToSelector(base, query) {
+    $('#test-details-container').css('min-height', $(window).height());
+    var anchor = query ? base + '?' + encodeURIComponent(query) : base;
+    window.location.hash = window.prevLocationHash = anchor;
+}
+
+function renderSelector(args, template, stats) {
+    window.elementsToRender = [];
+    var container = $('#test-details-container');
+    container.empty();
+    $.tmpl('detailsHeaderTemplate', args).appendTo(container);
+    $.tmpl(template, stats).appendTo(container);
+}
+
+function drawTestDetailsTable(tests, sortByStatus) {
+    if (!tests.length)
+        return;
+    renderTestDetailsHeader();
+    window.elementsToRender = tests;
+    var target = $('#test-details').find('tbody');
+    renderTestDetails(sortByStatus, target);
+}
+
+function renderTestDetailsHeader() {
+    var header = $.tmpl('testDetailsTableTemplate');
+    hideHiddenDetailsColumns(header);
+    header.appendTo('#test-details-container');
+}
+
+function sortByStatus(t1, t2) {
+    if (t1.status != t2.status)
+        return t1.status == 'FAIL' ? -1 : 1;
+    if (t1.isCritical != t2.isCritical)
+        return t1.isCritical ? -1 : 1;
+    return t1.fullName < t2.fullName ? -1 : 1;
+}
+
+function getTestsHavingTag(tag) {
+    return window.testdata.suite().searchTestsByTag(tag).sort(sortByStatus);
+}
+
+function getTotalTests(name) {
+    if (name == 'critical')
+        return window.testdata.suite().criticalTests().sort(sortByStatus);
+    return window.testdata.suite().allTests().sort(sortByStatus);
+}
+
+function calculateTotalTime(tests) {
+    var total = 0;
+    for (var i = 0, len = tests.length; i < len; i++)
+        total += tests[i].times.elapsedMillis;
+    return util.formatElapsed(total);
+}
+
+function calculatePassed(tests) {
+    var passed = util.filter(tests, function (test) {
+        return test.status == 'PASS';
+    });
+    return passed.length;
+}
+
+function renderTestDetails(sortByStatus, target) {
+    if (!window.elementsToRender.length)
+        return;
+    var tests = popUpTo(window.elementsToRender, 50);
+    renderTestDetailsRows(tests, target);
+    if (window.elementsToRender.length)
+        setTimeout(function () {renderTestDetails(sortByStatus, target);}, 0);
+    else
+        configureTableSorter(sortByStatus);
+}
+
+function renderTestDetailsRows(tests, target) {
+    var rows = $.tmpl('testDetailsTableRowTemplate', tests,
+                      {logURL: window.settings.logURL});
+    rows.find('a').click(stopPropagation);
+    hideHiddenDetailsColumns(rows);
+    rows.appendTo(target);
+}
+
+function configureTableSorter(sortByStatus) {
+    var config = {headers: {3: {sorter: 'criticality'},
+                            6: {sortInitialOrder: 'desc'},
+                            7: {sorter: 'times'}},
+                  selectorSort: '.details-col-header'};
+    if (sortByStatus)
+        config['sortList'] = [[4, 0], [3, 0]];
+    $('#test-details').tablesorter(config);
+}
+
+function popUpTo(list, upTo) {
+    var result = [];
+    while (list.length > 0 && result.length < upTo)
+        result.push(list.shift());
+    return result;
+}
+
+function toggleDetailsColumn(name) {
+    var column = $('.details-col-' + name);
+    column.toggleClass('hidden');
+    var hidden = column.hasClass('hidden');
+    storage.set(name, hidden ? 'hidden' : 'visible');
+    column.find('.details-col-toggle').html(hidden ? '&hellip;' : '&times;');
+}
+
+function hideHiddenDetailsColumns(elem) {
+    var names = ['doc', 'tags', 'msg', 'elapsed', 'times'];
+    for (var i = 0; i < names.length; i++) {
+        var name = names[i];
+        if (storage.get(name, 'visible') == 'hidden') {
+            var column = elem.find('.details-col-' + name);
+            column.addClass('hidden');
+            column.find('.details-col-toggle').html('&hellip;');
+        }
+    }
+}
+</script>
+
+<script type="text/x-jquery-tmpl" id="summaryTableTemplate">
+  <h2>Summary Information</h2>
+  <table class="details">
+    <tr>
+      <th>Status:</th>
+      {{if criticalFailed}}
+      <td><a href="#totals?critical" onclick="totalDetailSelected('critical')"
+             class="fail">${criticalFailed} critical test{{if criticalFailed != 1}}s{{/if}} failed</a></td>
+      {{else totalFailed}}
+      <td><a href="#totals?critical" onclick="totalDetailSelected('critical')"
+             class="pass">All critical tests passed</a></td>
+      {{else}}
+      <td><a href="#totals?all" onclick="totalDetailSelected('all')"
+             class="pass">All tests passed</a></td>
+      {{/if}}
+    </tr>
+    {{if doc()}}
+    <tr>
+      <th>Documentation:</th>
+      <td class="doc">{{html doc()}}</td>
+    </tr>
+    {{/if}}
+    {{each metadata}}
+    <tr>
+      <th>{{html $value[0]}}:</th>
+      <td class="doc">{{html $value[1]}}</td>
+    </tr>
+    {{/each}}
+    {{if times.startTime != 'N/A'}}
+    <tr>
+      <th>Start Time:</th>
+      <td>${times.startTime}</td>
+    </tr>
+    {{/if}}
+    {{if times.endTime != 'N/A'}}
+    <tr>
+      <th>End Time:</th>
+      <td>${times.endTime}</td>
+    </tr>
+    {{/if}}
+    <tr>
+      <th>Elapsed Time:</th>
+      <td>${times.elapsedTime}</td>
+    </tr>
+    {{if $item.logURL}}
+    <tr>
+      <th>Log File:</th>
+      <td><a href="${$item.logURL}">${$item.logURL}</a></td>
+    </tr>
+    {{/if}}
+  </table>
+</script>
+
+<script type="text/x-jquery-tmpl" id="totalStatisticsRowTemplate">
+  <tr onclick="totalDetailSelected('${type}')" class="row-${$item.index}">
+    <td class="stats-col-name">
+      <div class="stat-name">
+        <a href="#totals?${type}">{{html label}}</a>
+      </div>
+    </td>
+    {{tmpl($data) 'statColumnsTemplate'}}
+  </tr>
+</script>
+
+<script type="text/x-jquery-tmpl" id="tagStatisticsRowTemplate">
+  <tr onclick="tagDetailSelected('${label}')" class="row-${$item.index}">
+    <td class="stats-col-name" title="{{html doc}}">
+      <div class="stat-name">
+        <a href="#tags?${label}">{{html label}}</a>
+        {{if info}}(${info}){{/if}}
+      </div>
+      <div class="tag-links">
+        {{each links}}
+        <span>[<a href="{{html $value.url}}" onclick="stopPropagation(event)"
+                  title="{{html $value.url}}">{{html $value.title}}</a>]</span>
+        {{/each}}
+      </div>
+    </td>
+    {{tmpl($data) 'statColumnsTemplate'}}
+  </tr>
+</script>
+
+<script type="text/x-jquery-tmpl" id="suiteStatisticsRowTemplate">
+  <tr onclick="suiteDetailSelected('${id}')" class="row-${$item.index}">
+    <td class="stats-col-name" title="{{html label}}">
+      <div class="stat-name">
+        <a href="#suites?${id}"><span class="parent-name">{{html formatParentName}}</span>{{html name}}</a>
+      </div>
+    </td>
+    {{tmpl($data) 'statColumnsTemplate'}}
+  </tr>
+</script>
+
+<script type="text/x-jquery-tmpl" id="detailsHeaderTemplate">
+  <h2 id="${linkTarget}">Test Details</h2>
+  <ul id="detail-tabs">
+    <li class="${totalTabStatus} detail-tab">
+      <a href="#totals" onclick="renderTotalSelector()">Totals</a>
+    </li>
+    <li class="${tagTabStatus} detail-tab">
+      <a href="#tags" onclick="renderTagSelector()">Tags</a>
+    </li>
+    <li class="${suiteTabStatus} detail-tab">
+      <a href="#suites" onclick="renderSuiteSelector()">Suites</a>
+    </li>
+    <li class="${searchTabStatus} detail-tab">
+      <a href="#search" onclick="renderSearchSelector()">Search</a>
+    </li>
+  </ul>
+</script>
+
+<script  type="text/x-jquery-tmpl" id="totalDetailsSelectorTemplate">
+  <table class="details" id="details-header">
+    <tr class="selector">
+      <th>Type:</th>
+      <td id="normal-selector">
+        <input id="radio-critical" type="radio" name="totals-radio"
+               onclick="totalDetailSelected('critical')"
+               {{if selected == 'critical'}}checked="checked"{{/if}}>
+        <label for="radio-critical">Critical Tests</label><br>
+        <input id="radio-all" type="radio" name="totals-radio"
+               onclick="totalDetailSelected('all')"
+               {{if selected == 'all'}}checked="checked"{{/if}}>
+        <label for="radio-all">All Tests</label>
+      </td>
+      <td id="print-selector"></td>
+    </tr>
+  </table>
+</script>
+
+<script  type="text/x-jquery-tmpl" id="tagDetailsSelectorTemplate">
+  <table class="details" id="details-header">
+    <tr class="selector">
+      <th>Name:</th>
+      <td id="normal-selector">
+        <select id="tag-detail-selector"
+                onchange="tagDetailSelected(this.options[this.selectedIndex].value)">
+          <option value="">Select tag...</option>
+          {{each tags}}
+          <option value="${$value.label}"
+                  {{if $value.label == selected}}selected="selected"{{/if}}>
+            {{html $value.label}} {{if $value.info}}(${$value.info}){{/if}}
+          </option>
+          {{/each}}
+        </select>
+      </td>
+      <td id="print-selector"></td>
+    </tr>
+  </table>
+</script>
+
+<script  type="text/x-jquery-tmpl" id="suiteDetailsSelectorTemplate">
+  <table class="details" id="details-header">
+    <tr class="selector">
+      <th>Name:</th>
+      <td id="normal-selector">
+        <select id="suite-detail-selector"
+                onchange="suiteDetailSelected(this.options[this.selectedIndex].value)">
+          <option value="">Select suite...</option>
+          {{each suites}}
+          <option value="${$value.id}"
+                  {{if $value.id == selected}}selected="selected"{{/if}}>
+            {{html $value.label}}
+          </option>
+          {{/each}}
+        </select>
+      </td>
+      <td id="print-selector"></td>
+    </tr>
+  </table>
+</script>
+
+<script  type="text/x-jquery-tmpl" id="searchSelectorTemplate">
+  <form action="javascript:void(0)">
+    <table class="details" id="details-header">
+      <tr class="selector first-selector">
+        <th><label for="search-suite">Suite:</label></th>
+        <td><input id="search-suite" type="text" value="${suite}"></td>
+      </tr>
+      <tr class="selector middle-selector">
+        <th><label for="search-test">Test:</label></th>
+        <td><input id="search-test" type="text" value="${test}"></td>
+      </tr>
+      <tr class="selector middle-selector">
+        <th><label for="search-include">Include:</label></th>
+        <td><input id="search-include" type="text" value="${include}"></td>
+      </tr>
+      <tr class="selector middle-selector">
+        <th><label for="search-exclude">Exclude:</label></th>
+        <td><input id="search-exclude" type="text" value="${exclude}"></td>
+      </tr>
+      <tr class="selector last-selector" id="search-buttons">
+        <th></th>
+        <td>
+          <input type="submit" value="Search"
+                 onclick="searchExecuted($('#search-suite').val(),
+                                         $('#search-test').val(),
+                                         $('#search-include').val(),
+                                         $('#search-exclude').val())">
+          <input type="button" value="Clear"
+                 onclick="$('#search-suite').val('');
+                          $('#search-test').val('');
+                          $('#search-include').val('');
+                          $('#search-exclude').val('')">
+          <a href="javascript:void(0)" onclick="$('#search-help').toggle()"
+             title="Toggle search help.">Help</a>
+        </td>
+      </tr>
+      <tr id="search-help" style="display: none">
+        <th></th>
+        <td>
+          <div>
+            <h3>Search fields</h3>
+            <p>
+              Test cases can be searched based on test suite and test case
+              names as well as based on tags. If multiple search criteria are
+              used, only tests matching all of them are included.
+              Search fields have same semantics as <em>&#8209;&#8209;suite</em>,
+              <em>&#8209;&#8209;test</em>, <em>&#8209;&#8209;include</em> and
+              <em>&#8209;&#8209;exclude</em> command line options, respectively.
+            </p>
+            <table class="search-help-examples">
+              <col class="help-item">
+              <col class="help-explanation">
+              <col class="help-examples>
+              <tr>
+                <th>Field</th>
+                <th>Explanation</th>
+                <th>Examples</th>
+              </tr>
+              <tr>
+                <td>Suite</td>
+                <td>
+                  Tests in matching suites are included. The pattern can match
+                  either suite's name or its full name that contains also
+                  parent suite names.
+                </td>
+                <td>My Suite<br>Root.Parent.Sui*</td>
+              </tr>
+              <tr>
+                <td>Test</td>
+                <td>
+                  Matching tests are included. The pattern can match either
+                  test's name or its full name that contains also parent
+                  suite names.
+                </td>
+                <td>Test*<br>Root.Pa*.T???</td>
+              </tr>
+              <tr>
+                <td>Include</td>
+                <td>
+                  Tests that contain matching tags are included.
+                </td>
+                <td>smoke<br>bug-*</td>
+              </tr>
+              <tr>
+                <td>Exclude</td>
+                <td>
+                  Tests that contain matching tags are not included.
+                </td>
+                <td>slow<br>feature-4?</td>
+              </tr>
+            </table>
+            <h3>Patterns</h3>
+            <p>
+              All searches support <em>*</em> and <em>?</em> wildcards and are
+              case, space and underscore insensitive. Tag related searches also
+              support <em>AND</em>, <em>OR</em> and <em>NOT</em> (case-sensitive)
+              combining operators. If operators are used together, their
+              precedence, from highest to lowest, is <em>AND</em>, <em>OR</em>,
+              <em>NOT</em>. See <em>Simple patterns</em> and
+              <em>Tag patterns</em> sections in
+              <a href="http://robotframework.org/robotframework/#user-guide">Robot
+              Framework User Guide</a> version 2.8.4 or newer for more details.
+            </p>
+            <table class="search-help-examples">
+              <col class="help-item">
+              <col class="help-explanation">
+              <col class="help-examples>
+              <tr>
+                <th>Pattern</th>
+                <th>Explanation</th>
+                <th>Examples</th>
+              </tr>
+              <tr>
+                <td>*</td>
+                <td>Matches anything, even an empty string.</td>
+                <td>f*<br>sprint-*</td>
+              </tr>
+              <tr>
+                <td>?</td>
+                <td>Matches any single character.</td>
+                <td>f??<br>sprint-1?</td>
+              </tr>
+              <tr>
+                <td>AND</td>
+                <td>Matches if all patterns match.</td>
+                <td>foo AND bar<br>x AND y* AND z??</td>
+              </tr>
+              <tr>
+                <td>OR</td>
+                <td>Matches if any pattern matches.</td>
+                <td>foo OR bar<br>x OR y* OR z1 AND z2</td>
+              </tr>
+              <tr>
+                <td>NOT</td>
+                <td>
+                    Matches if (optional) pattern before matches and pattern
+                    after does not.
+                </td>
+                <td>foo NOT bar<br>* NOT id-* AND smoke<br>NOT bar</td>
+              </tr>
+            </table>
+          </div>
+        </td>
+      </tr>
+    </table>
+  </form>
+</script>
+
+<script type="text/x-jquery-tmpl" id="tagOrTotalDetailsTemplate">
+  <tr>
+    <th>Status:</th>
+    <td>${total} total, ${pass} passed, {{if fail}}<span class="fail">${fail} failed</span>{{else}}<span class="pass">0 failed</span>{{/if}}</td>
+  </tr>
+  {{if doc}}
+  <tr>
+    <th>Documentation:</th>
+    <td>{{html doc}}</td>
+  </tr>
+  {{/if}}
+  {{if combined}}
+  <tr>
+    <th>Pattern:</th>
+    <td>{{html combined}}</td>
+  </tr>
+  {{/if}}
+  {{if links}}{{if links.length}}
+  <tr>
+    <th>Links:</th>
+    <td>{{each links}}<a href="{{html $value.url}}"
+                         title="{{html $value.url}}">{{html $value.title}}</a> &nbsp; {{/each}}</td>
+  </tr>
+  {{/if}}{{/if}}
+  <tr>
+    <th>Total Time:</th>
+    <td>${totalTime}</td>
+  </tr>
+</script>
+
+<script type="text/x-jquery-tmpl" id="suiteDetailsTemplate">
+  <tr>
+    <th>Status:</th>
+    <td>{{tmpl($data) 'suiteStatusMessageTemplate'}}</td>
+  </tr>
+  {{if doc()}}
+  <tr>
+    <th>Documentation:</th>
+    <td class="doc">{{html doc()}}</td>
+  </tr>
+  {{/if}}
+  {{each metadata}}
+  <tr>
+    <th>{{html $value[0]}}:</th>
+    <td class="doc">{{html $value[1]}}</td>
+  </tr>
+  {{/each}}
+  {{if message()}}
+  <tr>
+    <th>Message:</th>
+    <td class="message">{{html message()}}</td>
+  </tr>
+  {{/if}}
+  <tr>
+    <th>Start / End Time:</th>
+    <td>${times.startTime} / ${times.endTime}</td>
+  </tr>
+  <tr>
+    <th>Elapsed Time:</th>
+    <td>${times.elapsedTime}</td>
+  </tr>
+  {{if $item.logURL}}
+  <tr>
+    <th>Log File:</th>
+    <td><a href="${$item.logURL}#${id}"
+           title="{{html fullName}}">${$item.logURL}#${id}</a></td>
+  </tr>
+  {{/if}}
+</script>
+
+<script type="text/x-jquery-tmpl" id="testDetailsTableTemplate">
+  <table id="test-details">
+    <thead>
+      <tr>
+        <th class="details-col-name" title="Name">
+          <div class='details-col-header'>Name</div>
+        </th>
+        <th class="details-col-doc" title="Documentation">
+          <div class='details-col-toggle' onclick="toggleDetailsColumn('doc')">&times;</div>
+          <div class='details-col-header'>Documentation</div>
+        </th>
+        <th class="details-col-tags" title="Tags">
+          <div class='details-col-toggle' onclick="toggleDetailsColumn('tags')">&times;</div>
+          <div class='details-col-header'>Tags</div>
+        </th>
+        <th class="details-col-crit" title="Critical">
+          <div class='details-col-header'>Crit.</div>
+        </th>
+        <th class="details-col-status" title="Status">
+          <div class='details-col-header'>Status</div>
+        </th>
+        <th class="details-col-msg" title="Message">
+          <div class='details-col-toggle' onclick="toggleDetailsColumn('msg')">&times;</div>
+          <div class='details-col-header'>Message</div>
+        </th>
+        <th class="details-col-elapsed" title="Elapsed Time">
+          <div class='details-col-toggle' onclick="toggleDetailsColumn('elapsed')">&times;</div>
+          <div class='details-col-header'>Elapsed</div>
+        </th>
+        <th class="details-col-times" title="Start Time / End Time">
+          <div class='details-col-toggle' onclick="toggleDetailsColumn('times')">&times;</div>
+          <div class='details-col-header'>Start / End</div>
+        </th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+</script>
+
+<script type="text/x-jquery-tmpl" id="testDetailsTableRowTemplate">
+  {{if $item.logURL}}
+  <tr onclick="location = '${$item.logURL}#${id}'" title="{{html fullName}}">
+    <td class="details-col-name">
+      <div><a href="${$item.logURL}#${id}"><span class="parent-name">{{html formatParentName}}</span>{{html name}}</a></div>
+    </td>
+  {{else}}
+  <tr title="{{html fullName}}">
+    <td class="details-col-name">
+      <div><span class="parent-name">{{html formatParentName}}</span>{{html name}}</div>
+    </td>
+  {{/if}}
+    <td class="details-col-doc"><div class="doc details-limited">{{html doc()}}</div></td>
+    <td class="details-col-tags"><div>{{html tags.join(', ')}}</div></td>
+    <td class="details-col-crit"><div>{{if isCritical}}yes{{else}}no{{/if}}</div></td>
+    <td class="details-col-status"><div><span class="label ${status.toLowerCase()}">${status}</span></div></td>
+    <td class="details-col-msg"><div class="message details-limited">{{html message()}}</div></td>
+    <td class="details-col-elapsed"><div>${times.elapsedTime}</div></td>
+    <td class="details-col-times"><div>${times.startTime}<br>${times.endTime}</div></td>
+  </tr>
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
As we're lacking acceptance test public output (see #212 ).

This is published a [github page](https://help.github.com/categories/github-pages-basics/) to enable direct html rendering.
Ideally we'd need to empty the branch to only keep a single index.html file. However, this will cause heavy extra git "working tree" updates each time we'll switch branch to update the report.

Lets thus wait to see it a too heavy github page site is an issue before doing the cleanup.
