### PR TITLE
Dot characters supported for cf set-env

### DIFF
--- a/doc/publish.md
+++ b/doc/publish.md
@@ -25,7 +25,7 @@ Autosleep service needs properties to work . The properties that are used are:
 There are two ways of providing these properties to autosleep.
 
 1. In _manifest.yml_: by giving these informations in the _manifest.yml_, in the _JAVA_OPTS_ section.
-2. By providing them with the command ```cf  set-env <application name> <property name>  <property value>```. Keep in mind that dot characters are forbidden by cloudfoundry and must be replaced by underscores. For example, you may provide the username like this ```cf  set-env my-autosleep-service cf_client_username  bobby```
+2. By providing them with the command ```cf  set-env <application name> <property name>  <property value>```.
 
 ### Deploy your app
 ```


### PR DESCRIPTION
I ran `cf set-env autosleep-app cf.service.broker.name autosleep-starkandwayne` successfully (prior to reading this warning that it wouldn't work). I believe we can remove this warning.