### PR TITLE
Logback displays packaging data (jars) in stack trace

### DIFF
--- a/common/src/main/resources/logback.xml
+++ b/common/src/main/resources/logback.xml
@@ -19,11 +19,11 @@
   ~ limitations under the License.
   -->
 
-<configuration debug="true">
+<configuration debug="true" packagingData="true">
     <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
         <Target>System.out</Target>
         <encoder>
-            <pattern>%-5level - %thread - %logger{5}\(%line\) - %message%n</pattern>
+            <pattern>%-5level - %thread - %logger{5}\(%line\) - %message%n %rEx{full}</pattern>
         </encoder>
     </appender>
     <logger name="org.cloudfoundry.autosleep">

--- a/common/src/test/java/org/cloudfoundry/autosleep/util/TestLogBackConfig.java
+++ b/common/src/test/java/org/cloudfoundry/autosleep/util/TestLogBackConfig.java
@@ -1,0 +1,23 @@
+package org.cloudfoundry.autosleep.util;
+
+import ch.qos.logback.classic.LoggerContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+/**
+ *
+ */
+public class TestLogBackConfig {
+
+    org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(TestLogBackConfig.class);
+
+    @Test
+    public void logBack_displays_exception_with_jar_names() {
+        Exception rootCause = new Exception("root cause");
+        Exception exception = new Exception("sample exception", rootCause);
+        log.info("inspect manually the displayed stack trace contains jars", exception);
+    }
+
+
+}

--- a/common/src/test/resources/logback.xml
+++ b/common/src/test/resources/logback.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<configuration debug="true">
+<configuration debug="true" packagingData="true">
     <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
         <Target>System.out</Target>
         <encoder>
-            <pattern>%-5level - %thread - %logger\(%line\) - %message%n</pattern>
+            <pattern>%-5level - %thread - %logger\(%line\) - %message%n %rEx{full}</pattern>
         </encoder>
     </appender>
     <logger name="org.cloudfoundry.autosleep" >


### PR DESCRIPTION
Logback displays packaging data (jars) in stack trace, and full root cause exceptions

As to ease diagnostic of cf-java-client related bugs
This requires specific activation since logback 1.1.4 due to performance impact.

See http://logback.qos.ch/manual/configuration.html#packagingData and http://logback.qos.ch/manual/layouts.html#xThrowable
