### PR TITLE
Introduce transient_opt_out as enrolment type to support org enrolment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,6 @@ branches:
     - develop
     - /^feature-.*$/
     - /^fix-.*$/
+    - transient-opt-out
 after_success:
   - ./gradlew jacocoRootReport coveralls
-notifications:
-  slack: autosleep:eY0VgmPawVzYa7tWKhmnBdES
-  slack: cloudfoundry:CxDiILV5x3kUYhJFfM2dCKxt

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ branches:
     - develop
     - /^feature-.*$/
     - /^fix-.*$/
-    - transient-opt-out
 after_success:
   - ./gradlew jacocoRootReport coveralls
+notifications:
+  slack: autosleep:eY0VgmPawVzYa7tWKhmnBdES
+  slack: cloudfoundry:CxDiILV5x3kUYhJFfM2dCKxt

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Download [latest release](https://github.com/cloudfoundry-community/autosleep/re
 
 ### What we are working on:
 
-We manage our roadmap as github issues, following is however an overview of planned short-term work:
+We manage our roadmap as github issues (also displayed as milestones in [huboard](https://huboard.com/cloudfoundry-community/autosleep). Detailed breakdown of org enrollement is in [pivotal tracker](https://www.pivotaltracker.com/n/projects/1891357), following is however an overview of planned short-term work:
 * Hardening, optimizations
 * Automatic enrollemnt of new spaces and orgs
 

--- a/common/src/main/java/org/cloudfoundry/autosleep/access/dao/model/SpaceEnrollerConfig.java
+++ b/common/src/main/java/org/cloudfoundry/autosleep/access/dao/model/SpaceEnrollerConfig.java
@@ -31,6 +31,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
+
+import org.cloudfoundry.autosleep.config.Config;
 import org.cloudfoundry.autosleep.util.serializer.IntervalDeserializer;
 import org.cloudfoundry.autosleep.util.serializer.IntervalSerializer;
 import org.cloudfoundry.autosleep.util.serializer.PatternDeserializer;
@@ -38,6 +40,8 @@ import org.cloudfoundry.autosleep.util.serializer.PatternSerializer;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.Id;
 import javax.persistence.Lob;
 
@@ -62,7 +66,8 @@ public class SpaceEnrollerConfig {
     private Pattern excludeFromAutoEnrollment;
 
     @JsonProperty
-    private boolean forcedAutoEnrollment;
+    @Enumerated(EnumType.ORDINAL)
+    private Config.ServiceInstanceParameters.Enrollment enrollment;
 
     @Id
     @JsonProperty

--- a/common/src/main/java/org/cloudfoundry/autosleep/config/Config.java
+++ b/common/src/main/java/org/cloudfoundry/autosleep/config/Config.java
@@ -99,7 +99,7 @@ public interface Config {
     interface ServiceInstanceParameters {
 
         enum Enrollment {
-            standard, forced
+            standard, forced, transient_opt_out
         }
 
         String AUTO_ENROLLMENT = "auto-enrollment";

--- a/common/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/common/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -260,3 +260,16 @@ databaseChangeLog:
         - column:
             name: state
             type: INT
+- changeSet:
+    id: 4
+    author: SAP
+    changes:
+    - renameColumn:
+        tableName: space_enroller_config
+        oldColumnName: forced_auto_enrollment
+        newColumnName: enrollment
+        columnDataType: BOOLEAN
+    - modifyDataType:
+        columnName: enrollment
+        newDataType: INT
+        tableName: space_enroller_config

--- a/spring-apps/autosleep-core/src/main/java/org/cloudfoundry/autosleep/ui/servicebroker/service/AutosleepBindingService.java
+++ b/spring-apps/autosleep-core/src/main/java/org/cloudfoundry/autosleep/ui/servicebroker/service/AutosleepBindingService.java
@@ -175,9 +175,11 @@ public class AutosleepBindingService implements ServiceInstanceBindingService {
                             log.debug("deleteServiceInstanceBinding on app {}", appId);
                             ApplicationInfo appInfo = appRepository.findOne(appId);
                             if (appInfo != null) {
-                                appInfo.getEnrollmentState()
-                                        .updateEnrollment(serviceInstance.getId(),
-                                                !serviceInstance.isForcedAutoEnrollment());
+                                appInfo.getEnrollmentState().updateEnrollment(serviceInstance.getId(), serviceInstance
+                                        .getEnrollment() != Config.ServiceInstanceParameters.Enrollment.forced
+                                        && serviceInstance
+                                                .getEnrollment() 
+                                                   != Config.ServiceInstanceParameters.Enrollment.transient_opt_out);
                                 if (appInfo.getEnrollmentState().getStates().isEmpty()) {
                                     appRepository.delete(appId);
                                     applicationLocker.removeApplication(appId);

--- a/spring-apps/autosleep-core/src/main/java/org/cloudfoundry/autosleep/ui/web/controller/DashboardController.java
+++ b/spring-apps/autosleep-core/src/main/java/org/cloudfoundry/autosleep/ui/web/controller/DashboardController.java
@@ -65,7 +65,8 @@ public class DashboardController {
             parameters.put("planId", serviceDefinition.getPlans().get(0).getId());
             parameters.put("serviceInstance", serviceInstanceId);
 
-            parameters.put("forcedAutoEnrollment", serviceInstance.isForcedAutoEnrollment());
+            parameters.put("enrollment",
+                    serviceInstance.getEnrollment());
             parameters.put("idleDuration", serviceInstance.getIdleDuration().toString());
             if (serviceInstance.getExcludeFromAutoEnrollment() != null) {
                 parameters.put("excludeFromAutoEnrollment",

--- a/spring-apps/autosleep-core/src/main/resources/templates/views/dashboard.tpl
+++ b/spring-apps/autosleep-core/src/main/resources/templates/views/dashboard.tpl
@@ -35,7 +35,7 @@ layout 'layouts/main.tpl',
                         }
                         li {
                             span {
-                                yield "forcedAutoEnrollment : $forcedAutoEnrollment"
+                                yield "enrollment : $enrollment"
                             }
                         }
                         li {

--- a/spring-apps/autosleep-core/src/test/java/org/cloudfoundry/autosleep/ui/servicebroker/service/AutosleepBindingServiceTest.java
+++ b/spring-apps/autosleep-core/src/test/java/org/cloudfoundry/autosleep/ui/servicebroker/service/AutosleepBindingServiceTest.java
@@ -29,6 +29,7 @@ import org.cloudfoundry.autosleep.access.dao.model.SpaceEnrollerConfig;
 import org.cloudfoundry.autosleep.access.dao.repositories.ApplicationRepository;
 import org.cloudfoundry.autosleep.access.dao.repositories.BindingRepository;
 import org.cloudfoundry.autosleep.access.dao.repositories.SpaceEnrollerConfigRepository;
+import org.cloudfoundry.autosleep.config.Config;
 import org.cloudfoundry.autosleep.config.DeployedApplicationConfig;
 import org.cloudfoundry.autosleep.util.ApplicationLocker;
 import org.cloudfoundry.autosleep.util.BeanGenerator;
@@ -172,7 +173,7 @@ public class AutosleepBindingServiceTest {
         final String serviceId = "testDelBinding";
 
         //given that autoEnrollment is standard
-        when(spaceEnrollerConfig.isForcedAutoEnrollment()).thenReturn(false);
+        when(spaceEnrollerConfig.getEnrollment()).thenReturn(Config.ServiceInstanceParameters.Enrollment.standard);
         when(spaceEnrollerConfig.getId()).thenReturn(serviceId);
 
         //mock the effect of "updateEnrollment(serviceId,true);
@@ -199,7 +200,7 @@ public class AutosleepBindingServiceTest {
         final DeleteServiceInstanceBindingRequest deleteRequest = prepareDeleteAppBindingTest(serviceId, bindingId);
 
         //given that autoEnrollment is forced
-        when(spaceEnrollerConfig.isForcedAutoEnrollment()).thenReturn(true);
+        when(spaceEnrollerConfig.getEnrollment()).thenReturn(Config.ServiceInstanceParameters.Enrollment.forced);
 
         //when unbinding the app
         bindingService.deleteServiceInstanceBinding(deleteRequest);
@@ -208,6 +209,26 @@ public class AutosleepBindingServiceTest {
         verify(enrollmentState, times(1)).updateEnrollment(anyString(), eq(false));
         verify(appRepo, times(1)).delete(applicationInfo.getUuid());
         //while binding should be deleted
+        verify(bindingRepository, times(1)).delete(bindingId);
+    }
+
+    @Test
+    public void delete_app_binding_should_clear_app_if_autoenrollment_is_transient_opt_out() throws Exception {
+        String bindingId = "testDelBindingTransientEnrollment";
+        String serviceId = "testDelBindingtransientEnrollment";
+        final DeleteServiceInstanceBindingRequest deleteRequest = prepareDeleteAppBindingTest(serviceId, bindingId);
+
+        // given that autoEnrollment is forced
+        when(spaceEnrollerConfig.getEnrollment())
+                .thenReturn(Config.ServiceInstanceParameters.Enrollment.transient_opt_out);
+
+        // when unbinding the app
+        bindingService.deleteServiceInstanceBinding(deleteRequest);
+
+        // then it should be cleared from database
+        verify(enrollmentState, times(1)).updateEnrollment(anyString(), eq(false));
+        verify(appRepo, times(1)).delete(applicationInfo.getUuid());
+        // while binding should be deleted
         verify(bindingRepository, times(1)).delete(bindingId);
     }
 

--- a/spring-apps/autosleep-core/src/test/java/org/cloudfoundry/autosleep/ui/servicebroker/service/AutosleepBindingServiceTest.java
+++ b/spring-apps/autosleep-core/src/test/java/org/cloudfoundry/autosleep/ui/servicebroker/service/AutosleepBindingServiceTest.java
@@ -218,7 +218,7 @@ public class AutosleepBindingServiceTest {
         String serviceId = "testDelBindingtransientEnrollment";
         final DeleteServiceInstanceBindingRequest deleteRequest = prepareDeleteAppBindingTest(serviceId, bindingId);
 
-        // given that autoEnrollment is forced
+        // given that autoEnrollment is transient
         when(spaceEnrollerConfig.getEnrollment())
                 .thenReturn(Config.ServiceInstanceParameters.Enrollment.transient_opt_out);
 

--- a/spring-apps/autosleep-core/src/test/java/org/cloudfoundry/autosleep/ui/servicebroker/service/AutosleepServiceInstanceServiceTest.java
+++ b/spring-apps/autosleep-core/src/test/java/org/cloudfoundry/autosleep/ui/servicebroker/service/AutosleepServiceInstanceServiceTest.java
@@ -483,7 +483,7 @@ public class AutosleepServiceInstanceServiceTest {
 
     @Test
     public void test_update_fails_when_transient_auto_enrollment_without_secret() throws Exception {
-        // given service exists
+        // given transient service with secret exists
         transient_service_with_secret_exist_in_database();
 
         // when user gives auto enrollment without secret

--- a/spring-apps/autosleep-core/src/test/java/org/cloudfoundry/autosleep/ui/servicebroker/service/parameters/ParameterReaderFactoryTest.java
+++ b/spring-apps/autosleep-core/src/test/java/org/cloudfoundry/autosleep/ui/servicebroker/service/parameters/ParameterReaderFactoryTest.java
@@ -76,9 +76,12 @@ public class ParameterReaderFactoryTest {
                 .readParameter(Enrollment.standard.name(), true);
         Enrollment forced = enrollmentParameterReader
                 .readParameter(Enrollment.forced.name(), false);
+        Enrollment transientOptOut = enrollmentParameterReader
+                .readParameter(Enrollment.transient_opt_out.name(), false);
         //Then we obtained the values from enum
         assertThat(standard, is(equalTo(Enrollment.standard)));
         assertThat(forced, is(equalTo(Enrollment.forced)));
+        assertThat(transientOptOut, is(equalTo(Enrollment.transient_opt_out)));
 
     }
 

--- a/spring-apps/autosleep-core/src/test/java/org/cloudfoundry/autosleep/ui/web/controller/DashboardControllerTest.java
+++ b/spring-apps/autosleep-core/src/test/java/org/cloudfoundry/autosleep/ui/web/controller/DashboardControllerTest.java
@@ -80,7 +80,7 @@ public class DashboardControllerTest {
 
         return SpaceEnrollerConfig.builder()
                 .idleDuration(Duration.parse("PT1M"))
-                .forcedAutoEnrollment(true)
+                .enrollment(Config.ServiceInstanceParameters.Enrollment.forced)
                 .secret("Pa$$w0rd")
                 .serviceDefinitionId(serviceDefinitionId)
                 .planId(planId)


### PR DESCRIPTION
1. Alter space_enroller_config schema changes
2. Support for "transient_opt_out" as a enrolment type
3. Requisite tests