### PR TITLE
Support app delete

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 }
 
 plugins {
-    id "io.spring.dependency-management" version "0.5.6.RELEASE"
+    id "io.spring.dependency-management" version "0.6.0.RELEASE"
     id "com.github.hierynomus.license" version "0.12.1"
 }
 

--- a/spring-apps/autosleep-core/src/main/java/org/cloudfoundry/autosleep/ui/servicebroker/service/AutosleepBindingService.java
+++ b/spring-apps/autosleep-core/src/main/java/org/cloudfoundry/autosleep/ui/servicebroker/service/AutosleepBindingService.java
@@ -45,7 +45,6 @@ import org.springframework.cloud.servicebroker.service.ServiceInstanceBindingSer
 import org.springframework.stereotype.Service;
 
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 
 import static org.cloudfoundry.autosleep.access.dao.model.Binding.ResourceType.Application;

--- a/spring-apps/autosleep-core/src/main/java/org/cloudfoundry/autosleep/ui/servicebroker/service/AutosleepBindingService.java
+++ b/spring-apps/autosleep-core/src/main/java/org/cloudfoundry/autosleep/ui/servicebroker/service/AutosleepBindingService.java
@@ -45,6 +45,7 @@ import org.springframework.cloud.servicebroker.service.ServiceInstanceBindingSer
 import org.springframework.stereotype.Service;
 
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 
 import static org.cloudfoundry.autosleep.access.dao.model.Binding.ResourceType.Application;
@@ -152,24 +153,27 @@ public class AutosleepBindingService implements ServiceInstanceBindingService {
             try {
                 //call CFAPI to get routes associated to app
                 List<String> mappedRouteIds = cfApi.listApplicationRoutes(appId);
-                //retrieve saved route bindings and compare
-                List<Binding> linkedRouteBindings = bindingRepository.findByResourceIdAndType(mappedRouteIds, Route);
-                if (linkedRouteBindings.size() > 0) {
-                    //clean all bindings in common set, provided they are related to the same service instance
-                    linkedRouteBindings.stream()
-                            .filter(linkedRouteBinding -> linkedRouteBinding.getServiceInstanceId().equals(serviceId))
-                            .forEach(linkedRouteBinding -> {
-                                log.debug("detected associated route binding {}, cleaning it", linkedRouteBinding
-                                        .getServiceBindingId());
-                                try {
-                                    //we had a proxy route binding for this app, clean it before remove app binding
-                                    cfApi.unbind(linkedRouteBinding.getServiceBindingId());
-                                } catch (CloudFoundryException e) {
-                                    log.error("Autosleep was unable to clear related route binding {}.",
-                                            linkedRouteBinding.getServiceBindingId());
-                                    bindingRepository.delete(linkedRouteBinding.getServiceBindingId());
-                                }
-                            });
+                //retrieve saved route bindings and compare, but only if there are still any... 
+                //bound routes are still not in place
+                if (mappedRouteIds.size() > 0) {
+                    List<Binding> linkedRouteBindings = bindingRepository.findByResourceIdAndType(mappedRouteIds, Route);
+                    if (linkedRouteBindings.size() > 0) {
+                        //clean all bindings in common set, provided they are related to the same service instance
+                        linkedRouteBindings.stream()
+                                .filter(linkedRouteBinding -> linkedRouteBinding.getServiceInstanceId().equals(serviceId))
+                                .forEach(linkedRouteBinding -> {
+                                    log.debug("detected associated route binding {}, cleaning it", linkedRouteBinding
+                                            .getServiceBindingId());
+                                    try {
+                                        //we had a proxy route binding for this app, clean it before remove app binding
+                                        cfApi.unbind(linkedRouteBinding.getServiceBindingId());
+                                    } catch (CloudFoundryException e) {
+                                        log.error("Autosleep was unable to clear related route binding {}.",
+                                                linkedRouteBinding.getServiceBindingId());
+                                        bindingRepository.delete(linkedRouteBinding.getServiceBindingId());
+                                    }
+                                });
+                    }
                 }
                 applicationLocker.executeThreadSafe(appId,
                         () -> {


### PR DESCRIPTION
At this moment, deleting an app bound to the autosleep service will fail. It always requires the app to be unbound from the service first. This is because of it trying to delete bindings for routes (which are not even supported, it seems).

This change only tries to delete route bindings if any is found. And then the delete can go on properly and the database is properly updated.