### PR TITLE
Keep proxy table clean

### DIFF
--- a/common/src/main/java/org/cloudfoundry/autosleep/access/dao/repositories/ProxyMapEntryRepository.java
+++ b/common/src/main/java/org/cloudfoundry/autosleep/access/dao/repositories/ProxyMapEntryRepository.java
@@ -22,7 +22,6 @@ package org.cloudfoundry.autosleep.access.dao.repositories;
 import org.cloudfoundry.autosleep.access.dao.model.ProxyMapEntry;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,5 +33,10 @@ public interface ProxyMapEntryRepository extends JpaRepository<ProxyMapEntry, St
     @Transactional
     @Query("DELETE FROM ProxyMapEntry e WHERE e.host = :host")
     void deleteIfExists(@Param("host") String host);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM ProxyMapEntry e WHERE e.appId = :appId")
+    void deleteAppRoutesIfExists(@Param("appId") String appId);
 
 }

--- a/spring-apps/autowakeup-proxy/src/main/java/org/cloudfoundry/autosleep/ui/proxy/WildcardProxy.java
+++ b/spring-apps/autowakeup-proxy/src/main/java/org/cloudfoundry/autosleep/ui/proxy/WildcardProxy.java
@@ -149,7 +149,7 @@ public class WildcardProxy {
             //TODO add timeout that would log error and reset mapEntry.isStarting to false
         }
         //if exist, to prevent exception when two instances started the app in //
-        proxyMap.deleteIfExists(mapEntry.getHost());
+        proxyMap.deleteAppRoutesIfExists(appId);
         String protocol = incoming.getHeaders().get(HEADER_PROTOCOL).get(0);
         URI uri = URI.create(protocol + "://" + targetHost + path);
         RequestEntity<?> outgoing = getOutgoingRequest(incoming, uri);

--- a/spring-apps/autowakeup-proxy/src/test/java/org/cloudfoundry/autosleep/ui/proxy/WildcardProxyTest.java
+++ b/spring-apps/autowakeup-proxy/src/test/java/org/cloudfoundry/autosleep/ui/proxy/WildcardProxyTest.java
@@ -170,7 +170,7 @@ public class WildcardProxyTest {
         // and we never wait for anything
         verify(timeManager, never()).sleep(Config.PERIOD_BETWEEN_STATE_CHECKS_DURING_RESTART);
         //and we removed the application from repository
-        verify(proxyMap, times(1)).deleteIfExists(HOST_TEST_VALUE);
+        verify(proxyMap, times(1)).deleteAppRoutesIfExists(APP_ID);
     }
 
     @Test
@@ -277,7 +277,7 @@ public class WildcardProxyTest {
         verify(cfApi, times(1)).startApplication(APP_ID);
         verify(timeManager, times(3)).sleep(Config.PERIOD_BETWEEN_STATE_CHECKS_DURING_RESTART);
         //and we removed the application from repository
-        verify(proxyMap, times(1)).deleteIfExists(HOST_TEST_VALUE);
+        verify(proxyMap, times(1)).deleteAppRoutesIfExists(APP_ID);
     }
 
 }


### PR DESCRIPTION
At this moment, when an app is awaken, only the called route (the one triggering the startup) will be deleted from the proxy map table. This will cause clutter in the long run, as the route entries will be kept in the table for as long as they are not used to wake up the app again.

This change will remove all mapped routes for an app when it is awaken instead of just the used route. 